### PR TITLE
Live Reloading

### DIFF
--- a/fasthtml/__init__.py
+++ b/fasthtml/__init__.py
@@ -3,3 +3,4 @@ from .core import *
 from .authmw import *
 from .components import *
 from .xtend import *
+from .live_reload import *

--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -202,7 +202,14 @@ class RouterX(Router):
     def add_route( self, path: str, endpoint: callable, methods=None, name=None, include_in_schema=True):
         route = RouteX(path, endpoint=endpoint, methods=methods, name=name, include_in_schema=include_in_schema,
                       hdrs=self.hdrs, before=self.before, **self.bodykw)
-        self.routes = [o for o in self.routes if o.methods!=methods or o.path!=path]
+        # TODO:
+        #  self.routes = [o for o in self.routes if or o.methods != methods or o.path != path]
+        #  throws the following error for a WebSocketRoute:
+        #    `AttributeError: 'WebSocketRoute' object has no attribute 'methods'`
+        #  not 100% sure what the `if or o.methods != methods or o.path != path` check does,
+        #  so here's a temporary placeholder fix before we figure out something better.
+        self.routes = [o for o in self.routes if
+                       isinstance(self.routes[0], WebSocketRoute) or o.methods != methods or o.path != path]
         self.routes.append(route)
 
 htmxscr = Script(

--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -202,14 +202,7 @@ class RouterX(Router):
     def add_route( self, path: str, endpoint: callable, methods=None, name=None, include_in_schema=True):
         route = RouteX(path, endpoint=endpoint, methods=methods, name=name, include_in_schema=include_in_schema,
                       hdrs=self.hdrs, before=self.before, **self.bodykw)
-        # TODO:
-        #  self.routes = [o for o in self.routes if or o.methods != methods or o.path != path]
-        #  throws the following error for a WebSocketRoute:
-        #    `AttributeError: 'WebSocketRoute' object has no attribute 'methods'`
-        #  not 100% sure what the `if or o.methods != methods or o.path != path` check does,
-        #  so here's a temporary placeholder fix before we figure out something better.
-        self.routes = [o for o in self.routes if
-                       isinstance(self.routes[0], WebSocketRoute) or o.methods != methods or o.path != path]
+        self.routes = [o for o in self.routes if o.methods != methods or o.path != path]
         self.routes.append(route)
 
 htmxscr = Script(

--- a/fasthtml/live_reload.py
+++ b/fasthtml/live_reload.py
@@ -22,6 +22,7 @@ LIVE_RELOAD_SCRIPT = """
     })();
 """
 
+
 async def live_reload_websocket(websocket):
     await websocket.accept()
 
@@ -54,6 +55,7 @@ class FastHTMLWithLiveReload(FastHTML):
     LIVE_RELOAD_ROUTE = WebSocketRoute("/live-reload", endpoint=live_reload_websocket)
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("hdrs", []).append(self.LIVE_RELOAD_HEADER)
-        kwargs.setdefault("routes", []).append(self.LIVE_RELOAD_ROUTE)
+        # "hdrs" and "routes" can be missing, None, a list or a tuple.
+        kwargs["hdrs"] = [*(kwargs.get("hdrs") or []), self.LIVE_RELOAD_HEADER]
+        kwargs["routes"] = [*(kwargs.get("routes") or []), self.LIVE_RELOAD_ROUTE]
         super().__init__(*args, **kwargs)

--- a/fasthtml/live_reload.py
+++ b/fasthtml/live_reload.py
@@ -3,17 +3,24 @@ from fasthtml import FastHTML, Script
 
 __all__ = ["FastHTMLWithLiveReload"]
 
-# TODO:
-#  making a single attempt to reload the browser 1 second after the `onclose` event
-#  is pretty basic. Let's look at some existing implementations and see if we can
-#  make the reload more robust.
+
 LIVE_RELOAD_SCRIPT = """
     (function() {
         var socket = new WebSocket(`ws://${window.location.host}/live-reload`);
-        socket.onclose = function() {setTimeout(window.location.reload(), 1000)};
+        var maxReloadAttempts = 20;
+        var reloadInterval = 250; // time between reload attempts in ms
+        socket.onclose = function() {
+            let reloadAttempts = 0;
+            const intervalFn = setInterval(function(){
+                window.location.reload();
+                reloadCount++;
+                if (reloadAttempts === maxReloadAttempts) {
+                    clearInterval(intervalFn);
+                };
+            }, reloadInterval);
+        }
     })();
 """
-
 
 async def live_reload_websocket(websocket):
     await websocket.accept()
@@ -29,15 +36,12 @@ class FastHTMLWithLiveReload(FastHTML):
       - a websocket is creaetd at `/live-reload`
       - a small js snippet `LIVE_RELOAD_SCRIPT` is injected into each webpage
       - this snippet connects to the websocket at `/live-reload` and listens for an `onclose` event
-      - when the onclose event is detected the browser reloads after 1 second
+      - when the onclose event is detected the browser is reloaded
 
     Why do we listen for an `onclose` event?
       When code changes are saved the server automatically reloads if the --reload flag is set.
       The server reload kills the websocket connection. The `onclose` event serves as a proxy
       for "developer has saved some changes".
-
-    Why do we wait for 1 second before reloading the browser?
-      We need to allow some time for uvicorn to reload and start serving the latest changes.
 
     Usage
         >>> from fasthtml.all import *

--- a/fasthtml/live_reload.py
+++ b/fasthtml/live_reload.py
@@ -1,0 +1,55 @@
+from starlette.routing import WebSocketRoute
+from fasthtml import FastHTML, Script
+
+__all__ = ["FastHTMLWithLiveReload"]
+
+# TODO:
+#  making a single attempt to reload the browser 1 second after the `onclose` event
+#  is pretty basic. Let's look at some existing implementations and see if we can
+#  make the reload more robust.
+LIVE_RELOAD_SCRIPT = """
+    (function() {
+        var socket = new WebSocket(`ws://${window.location.host}/live-reload`);
+        socket.onclose = function() {setTimeout(window.location.reload(), 1000)};
+    })();
+"""
+
+
+async def live_reload_websocket(websocket):
+    await websocket.accept()
+
+
+class FastHTMLWithLiveReload(FastHTML):
+    """
+    `FastHTMLWithLiveReload` enables live reloading.
+    This means that any code changes saved on the server will automatically
+    trigger a reload of both the server and browser window.
+
+    How does it work?
+      - a websocket is creaetd at `/live-reload`
+      - a small js snippet `LIVE_RELOAD_SCRIPT` is injected into each webpage
+      - this snippet connects to the websocket at `/live-reload` and listens for an `onclose` event
+      - when the onclose event is detected the browser reloads after 1 second
+
+    Why do we listen for an `onclose` event?
+      When code changes are saved the server automatically reloads if the --reload flag is set.
+      The server reload kills the websocket connection. The `onclose` event serves as a proxy
+      for "developer has saved some changes".
+
+    Why do we wait for 1 second before reloading the browser?
+      We need to allow some time for uvicorn to reload and start serving the latest changes.
+
+    Usage
+        >>> from fasthtml.all import *
+        >>> app = FastHTMLWithLiveReload()
+
+        Run:
+            uvicorn main:app --reload
+    """
+    LIVE_RELOAD_HEADER = Script(f'{LIVE_RELOAD_SCRIPT}')
+    LIVE_RELOAD_ROUTE = WebSocketRoute("/live-reload", endpoint=live_reload_websocket)
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("hdrs", []).append(self.LIVE_RELOAD_HEADER)
+        kwargs.setdefault("routes", []).append(self.LIVE_RELOAD_ROUTE)
+        super().__init__(*args, **kwargs)

--- a/fasthtml/starlette.py
+++ b/fasthtml/starlette.py
@@ -11,7 +11,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException
 from starlette._utils import is_async_callable
 from starlette.convertors import Convertor, StringConvertor, register_url_convertor, CONVERTOR_TYPES
-from starlette.routing import Route, Router, Mount
+from starlette.routing import Route, Router, Mount, WebSocketRoute
 from starlette.exceptions import HTTPException,WebSocketException
 from starlette.endpoints import HTTPEndpoint,WebSocketEndpoint
 from starlette.config import Config

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -711,6 +711,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Live Reloading\n",
+    "When building your app it can be useful to view your changes in a web browser as you make them. FastHTML supports live reloading which means that it watches for any changes to your code and automatically refreshes the webpage in your browser.\n",
+    "\n",
+    "To enable live reloading simply replace `FastHTML` in your app with `FastHTMLWithLiveReload`.\n",
+    "\n",
+    "```python\n",
+    "from fasthtml.all import *\n",
+    "app = FastHTMLWithLiveReload()\n",
+    "```\n",
+    "\n",
+    "Then in your terminal run `uvicorn` with reloading enabled.\n",
+    "\n",
+    "```\n",
+    "uvicorn: main:app --reload\n",
+    "```\n",
+    "\n",
+    "**⚠️ Gotchas**\n",
+    "- A reload is only triggered when you save your changes.\n",
+    "- `FastHTMLWithLiveReload` should only be used during development.\n",
+    "- If your app spans multiple directories you might need to use the `--reload-dir` flag to watch all files in each directory. See the uvicorn [docs](https://www.uvicorn.org/settings/#development) for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## fin -"
    ]
   },

--- a/settings.ini
+++ b/settings.ini
@@ -4,7 +4,7 @@ lib_name = fasthtml
 version = 0.0.11
 min_python = 3.10
 license = apache2
-requirements = fastcore>=1.5.45 python-dateutil starlette oauthlib itsdangerous uvicorn httpx fastlite>=0.0.6 python-multipart
+requirements = fastcore>=1.5.45 python-dateutil starlette oauthlib itsdangerous uvicorn[standard] httpx fastlite>=0.0.6 python-multipart sqlite-utils
 dev_requirements = ipython lxml
 black_formatting = False
 conda_user = fastai

--- a/settings.ini
+++ b/settings.ini
@@ -4,7 +4,7 @@ lib_name = fasthtml
 version = 0.0.11
 min_python = 3.10
 license = apache2
-requirements = fastcore>=1.5.45 python-dateutil starlette oauthlib itsdangerous uvicorn[standard] httpx fastlite>=0.0.6 python-multipart sqlite-utils
+requirements = fastcore>=1.5.45 python-dateutil starlette oauthlib itsdangerous uvicorn[standard] httpx fastlite>=0.0.6 python-multipart
 dev_requirements = ipython lxml
 black_formatting = False
 conda_user = fastai


### PR DESCRIPTION
This PR includes a basic implementation of live reloading.

How does the implementation work?
A subclass of FastHTML (FastHTMLWithLiveReload) does the following: 
  - adds a websocket at `/live-reload`
  - injects a small javascript snippet `LIVE_RELOAD_SCRIPT` to each webpage
  - this snippet allows the browser and server to communicate with each other
  - as a result the browser can "detect" code changes on the server and reload

Here are some items to resolve:
- [x] more robust reloading
- [x] unit tests
- [x] documentation
- [x]  test reloading with local static file