### PR TITLE
In html2xt, move class to end

### DIFF
--- a/fasthtml/components.py
+++ b/fasthtml/components.py
@@ -132,7 +132,10 @@ def html2xt(html):
         cs = [repr(c.strip()) if isinstance(c, str) else _parse(c, lvl+1)
               for c in cts if str(c).strip()]
         attrs = []
-        for key, value in elm.attrs.items():
+        elm_attrs = list(elm.attrs.items())
+        cls_idx = next((i for i, item in enumerate(elm_attrs) if item[0] == 'class'), None)
+        if cls_idx is not None: elm_attrs.append(elm_attrs.pop(cls_idx))
+        for key, value in elm_attrs:
             if isinstance(value,(tuple,list)): value = " ".join(value)
             attrs.append(f'{rev_map.get(key, key).replace("-", "_")}={value!r}')
         spc = " "*lvl*indent

--- a/nbs/01_components.ipynb
+++ b/nbs/01_components.ipynb
@@ -265,9 +265,9 @@
        "```xml\n",
        "<form>\n",
        "  <fieldset>\n",
-       "    <input id=\"title\" name=\"title\" value=\"Profit\"></input>\n",
+       "    <input id=\"title\" class=\"char\" name=\"title\" value=\"Profit\"></input>\n",
        "    <label>\n",
-       "      <input type=\"checkbox\" data-foo=\"bar\" id=\"done\" name=\"done\" checked=\"1\"></input>\n",
+       "      <input type=\"checkbox\" data-foo=\"bar\" id=\"done\" class=\"checkboxer\" name=\"done\" checked=\"1\"></input>\n",
        "Done\n",
        "    </label>\n",
        "    <input type=\"hidden\" id=\"id\" name=\"id\" value=\"2\"></input>\n",
@@ -281,13 +281,16 @@
       "text/plain": [
        "['form',\n",
        " (['fieldset',\n",
-       "   (['input', (), {'id': 'title', 'name': 'title', 'value': 'Profit'}],\n",
+       "   (['input',\n",
+       "     (),\n",
+       "     {'id': 'title', 'class': 'char', 'name': 'title', 'value': 'Profit'}],\n",
        "    ['label',\n",
        "     (['input',\n",
        "       (),\n",
        "       {'type': 'checkbox',\n",
        "        'data-foo': 'bar',\n",
        "        'id': 'done',\n",
+       "        'class': 'checkboxer',\n",
        "        'name': 'done',\n",
        "        'checked': '1'}],\n",
        "      'Done'),\n",
@@ -310,8 +313,8 @@
     "    title:str; id:int; done:bool; details:str\n",
     "                \n",
     "todo = TodoItem(id=2, title=\"Profit\", done=True, details=\"Details\")\n",
-    "check = Label(Input(type=\"checkbox\", id=\"done\", data_foo=\"bar\"), \"Done\")\n",
-    "form = Form(Fieldset(Input(id=\"title\"), check, Input(type=\"hidden\", id=\"id\"), Textarea(id='details'), Button(\"Save\")))\n",
+    "check = Label(Input(type=\"checkbox\", cls=\"checkboxer\", id=\"done\", data_foo=\"bar\"), \"Done\")\n",
+    "form = Form(Fieldset(Input(cls=\"char\", id=\"title\"), check, Input(type=\"hidden\", id=\"id\"), Textarea(id='details'), Button(\"Save\")))\n",
     "form = fill_form(form, todo)\n",
     "form"
    ]
@@ -384,7 +387,9 @@
     {
      "data": {
       "text/plain": [
-       "[['input', (), {'id': 'title', 'name': 'title', 'value': 'Profit'}]]"
+       "[['input',\n",
+       "  (),\n",
+       "  {'id': 'title', 'class': 'char', 'name': 'title', 'value': 'Profit'}]]"
       ]
      },
      "execution_count": null,
@@ -461,7 +466,10 @@
     "        cs = [repr(c.strip()) if isinstance(c, str) else _parse(c, lvl+1)\n",
     "              for c in cts if str(c).strip()]\n",
     "        attrs = []\n",
-    "        for key, value in elm.attrs.items():\n",
+    "        elm_attrs = list(elm.attrs.items())\n",
+    "        cls_idx = next((i for i, item in enumerate(elm_attrs) if item[0] == 'class'), None)\n",
+    "        if cls_idx is not None: elm_attrs.append(elm_attrs.pop(cls_idx))\n",
+    "        for key, value in elm_attrs:\n",
     "            if isinstance(value,(tuple,list)): value = \" \".join(value)\n",
     "            attrs.append(f'{rev_map.get(key, key).replace(\"-\", \"_\")}={value!r}')\n",
     "        spc = \" \"*lvl*indent\n",
@@ -486,9 +494,9 @@
        "```python\n",
        "Form(\n",
        "    Fieldset(\n",
-       "        Input(id='title', name='title', value='Profit'),\n",
+       "        Input(id='title', name='title', value='Profit', cls='char'),\n",
        "        Label(\n",
-       "            Input(type='checkbox', data_foo='bar', id='done', name='done', checked='1'),\n",
+       "            Input(type='checkbox', data_foo='bar', id='done', name='done', checked='1', cls='checkboxer'),\n",
        "            'Done'\n",
        "        ),\n",
        "        Input(type='hidden', id='id', name='id', value='2'),\n",
@@ -530,14 +538,6 @@
     "#|hide\n",
     "import nbdev; nbdev.nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0a942593",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The `cls` argument is now moved to the end of the result of the html2xt function. So this:

```html
<form>
  <fieldset>
    <input id="title" class="char" name="title" value="Profit"></input>
    <label>
      <input type="checkbox" data-foo="bar" id="done" class="checkboxer" name="done" checked="1"></input>
Done
    </label>
    <input type="hidden" id="id" name="id" value="2"></input>
    <textarea id="details" name="details">Details</textarea>
    <button>Save</button>
  </fieldset>
</form>
```

becomes this:

```python
python
Form(
    Fieldset(
        Input(id='title', name='title', value='Profit', cls='char'),
        Label(
            Input(type='checkbox', data_foo='bar', id='done', name='done', checked='1', cls='checkboxer'),
            'Done'
        ),
        Input(type='hidden', id='id', name='id', value='2'),
        Textarea('Details', id='details', name='details'),
        Button('Save')
    )
)
```