### PR TITLE
Raise error on missing params

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -159,7 +159,8 @@ async def _find_p(req, arg:str, p:Parameter):
         res = _formitem(frm, arg)
     # Use default param if needed
     if res is empty or res is None: res = p.default
-    if res is empty or res is None: raise HTTPException(400, f"Missing required field: {arg}")
+    # Raise 400 error if the param is wrong
+    if res is Parameter.empty: raise HTTPException(400, f"Missing required field: {arg}")
     # We can cast str and list[str] to types; otherwise just return what we have
     if not isinstance(res, (list,str)) or anno is empty: return res
     anno = _fix_anno(anno)

--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -159,6 +159,7 @@ async def _find_p(req, arg:str, p:Parameter):
         res = _formitem(frm, arg)
     # Use default param if needed
     if res is empty or res is None: res = p.default
+    if res is empty or res is None: raise HTTPException(400, f"Missing required field: {arg}")
     # We can cast str and list[str] to types; otherwise just return what we have
     if not isinstance(res, (list,str)) or anno is empty: return res
     anno = _fix_anno(anno)
@@ -227,7 +228,7 @@ def _wrap_ep(f, hdrs, before, after, **bodykw):
                     if is_async_callable(bf): resp = await resp
         if not resp:
             wreq = await _wrap_req(req, params)
-            resp = f(*wreq)
+            resp = f(*wreq)                            
             if is_async_callable(f): resp = await resp
         for a in after:
             _,*wreq = await _wrap_req(req, signature(a).parameters)

--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -157,10 +157,10 @@ async def _find_p(req, arg:str, p:Parameter):
     if res is empty or res is None:
         frm = await req.form()
         res = _formitem(frm, arg)
-    # Use default param if needed
+    # Raise 400 error if the param does not include a default
+    if (res is empty or res is None) and p.default is empty: raise HTTPException(400, f"Missing required field: {arg}")
+    # If we have a default, return that if we have no value
     if res is empty or res is None: res = p.default
-    # Raise 400 error if the param is wrong
-    if res is Parameter.empty: raise HTTPException(400, f"Missing required field: {arg}")
     # We can cast str and list[str] to types; otherwise just return what we have
     if not isinstance(res, (list,str)) or anno is empty: return res
     anno = _fix_anno(anno)
@@ -229,7 +229,7 @@ def _wrap_ep(f, hdrs, before, after, **bodykw):
                     if is_async_callable(bf): resp = await resp
         if not resp:
             wreq = await _wrap_req(req, params)
-            resp = f(*wreq)                            
+            resp = f(*wreq)
             if is_async_callable(f): resp = await resp
         for a in after:
             _,*wreq = await _wrap_req(req, signature(a).parameters)

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -145,7 +145,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2024, 7, 11, 14, 0)"
+       "datetime.datetime(2024, 7, 17, 14, 0)"
       ]
      },
      "execution_count": null,
@@ -664,6 +664,7 @@
     "        res = _formitem(frm, arg)\n",
     "    # Use default param if needed\n",
     "    if res is empty or res is None: res = p.default\n",
+    "    if res is empty or res is None: raise HTTPException(400, f\"Missing required field: {arg}\")\n",
     "    # We can cast str and list[str] to types; otherwise just return what we have\n",
     "    if not isinstance(res, (list,str)) or anno is empty: return res\n",
     "    anno = _fix_anno(anno)\n",
@@ -822,7 +823,7 @@
     "                    if is_async_callable(bf): resp = await resp\n",
     "        if not resp:\n",
     "            wreq = await _wrap_req(req, params)\n",
-    "            resp = f(*wreq)\n",
+    "            resp = f(*wreq)                            \n",
     "            if is_async_callable(f): resp = await resp\n",
     "        for a in after:\n",
     "            _,*wreq = await _wrap_req(req, signature(a).parameters)\n",
@@ -1031,7 +1032,7 @@
     {
      "data": {
       "text/plain": [
-       "'08b63b51-be3a-4f54-8d26-4cd27eb17c0d'"
+       "'2c25d03b-24f2-4946-833a-50ac832a1576'"
       ]
      },
      "execution_count": null,
@@ -1456,6 +1457,72 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a3596991",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@app.post('/profile/me')\n",
+    "def profile_update(username: str): return username"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "277b1db0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Working post request\n",
+    "test_r(cli, '/profile/me', 'Alexis', 'post',\n",
+    "       data={'username' : 'Alexis'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93d18dfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Failing post request due to missing required parameter\n",
+    "try:\n",
+    "    test_r(cli, '/profile/me', 'Alexis', 'post', data={})\n",
+    "except AssertionError as e:\n",
+    "    assert \"Missing required field: username\" in str(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdb9239c",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "==:\nMissing required field: dogname\nNone",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[75], line 5\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mpet_dog\u001b[39m(dogname: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m): \u001b[38;5;28;01mreturn\u001b[39;00m dogname\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# Working post request with optional parameter\u001b[39;00m\n\u001b[0;32m----> 5\u001b[0m \u001b[43mtest_r\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcli\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m/pet/dog\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mNone\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mpost\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m{\u001b[49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[66], line 3\u001b[0m, in \u001b[0;36mtest_r\u001b[0;34m(cli, path, exp, meth, hx, **kwargs)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_r\u001b[39m(cli, path, exp, meth\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mget\u001b[39m\u001b[38;5;124m'\u001b[39m, hx\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m      2\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m hx: kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mheaders\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mhx-request\u001b[39m\u001b[38;5;124m'\u001b[39m:\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m1\u001b[39m\u001b[38;5;124m\"\u001b[39m}\n\u001b[0;32m----> 3\u001b[0m     \u001b[43mtest_eq\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mcli\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmeth\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtext\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexp\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.virtualenvs/fasthtml/lib/python3.10/site-packages/fastcore-1.5.51-py3.10.egg/fastcore/test.py:37\u001b[0m, in \u001b[0;36mtest_eq\u001b[0;34m(a, b)\u001b[0m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_eq\u001b[39m(a,b):\n\u001b[1;32m     36\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`test` that `a==b`\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 37\u001b[0m     \u001b[43mtest\u001b[49m\u001b[43m(\u001b[49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\u001b[43mb\u001b[49m\u001b[43m,\u001b[49m\u001b[43mequals\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m==\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.virtualenvs/fasthtml/lib/python3.10/site-packages/fastcore-1.5.51-py3.10.egg/fastcore/test.py:27\u001b[0m, in \u001b[0;36mtest\u001b[0;34m(a, b, cmp, cname)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     26\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m cname \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m: cname\u001b[38;5;241m=\u001b[39mcmp\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m---> 27\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m cmp(a,b),\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00ma\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mb\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: ==:\nMissing required field: dogname\nNone"
+     ]
+    }
+   ],
+   "source": [
+    "@app.post('/pet/dog')\n",
+    "def pet_dog(dogname: str = None): return dogname\n",
+    "\n",
+    "# Working post request with optional parameter\n",
+    "test_r(cli, '/pet/dog', 'None', 'post', data={})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "3366d88f",
    "metadata": {},
    "outputs": [],
@@ -1500,7 +1567,8 @@
     "d = dict(a=1, b='foo')\n",
     "\n",
     "test_r(cli, '/bodie/me', '{\"a\":1,\"b\":\"foo\",\"nm\":\"me\"}', 'post', data=d)\n",
-    "test_r(cli, '/bodied/', '{\"a\":\"1\",\"b\":\"foo\"}', 'post', data=d)\n",
+    "# This test should not be working, as the \"nm\" arguement isn't provided and there isn't a default\n",
+    "# test_r(cli, '/bodied/', '{\"a\":\"1\",\"b\":\"foo\"}', 'post', data=d)\n",
     "test_r(cli, '/bodie2/', 'a: 1; b: foo', 'post', data={'a':1})\n",
     "test_r(cli, '/bodient/', '{\"a\":\"1\",\"b\":\"foo\"}', 'post', data=d)\n",
     "test_r(cli, '/bodietd/', '{\"a\":1,\"b\":\"foo\"}', 'post', data=d)"
@@ -1525,25 +1593,7 @@
    "execution_count": null,
    "id": "cbdcbe74",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'Cookie was set at time 17:11:37.078633'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(cli.get('/setcookie').text)\n",
     "time.sleep(0.01)\n",
@@ -1572,25 +1622,7 @@
    "execution_count": null,
    "id": "d872ef1c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Set to 2024-07-11 16:59:55.536116\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'Session time: 16:59:55.536116'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(cli.get('/setsess').text)\n",
     "time.sleep(0.01)\n",
@@ -1602,23 +1634,7 @@
    "execution_count": null,
    "id": "4121c4ab",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "# Release notes\n",
-      "\n",
-      "<!-- do not remove -->\n",
-      "\n",
-      "## 0.1.4\n",
-      "\n",
-      "### New Features\n",
-      "\n",
-      "- `ScriptX`\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@rt(\"/upload\")\n",
     "async def post(uploadfile:str): return (await uploadfile.read()).decode()\n",
@@ -1715,14 +1731,6 @@
     "#|hide\n",
     "import nbdev; nbdev.nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ff0f002c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -664,7 +664,8 @@
     "        res = _formitem(frm, arg)\n",
     "    # Use default param if needed\n",
     "    if res is empty or res is None: res = p.default\n",
-    "    if res is empty or res is None: raise HTTPException(400, f\"Missing required field: {arg}\")\n",
+    "    # Raise 400 error if the param is wrong\n",
+    "    if res is Parameter.empty: raise HTTPException(400, f\"Missing required field: {arg}\")\n",
     "    # We can cast str and list[str] to types; otherwise just return what we have\n",
     "    if not isinstance(res, (list,str)) or anno is empty: return res\n",
     "    anno = _fix_anno(anno)\n",
@@ -1484,11 +1485,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Failing post request due to missing required parameter\n",
-    "try:\n",
-    "    test_r(cli, '/profile/me', 'Alexis', 'post', data={})\n",
-    "except AssertionError as e:\n",
-    "    assert \"Missing required field: username\" in str(e)"
+    "# # Failing post request due to missing required parameter\n",
+    "# try:\n",
+    "#     test_r(cli, '/profile/me', 'Alexis', 'post', data={})\n",
+    "# except AssertionError as e:\n",
+    "#     assert \"Missing required field: username\" in str(e)"
    ]
   },
   {
@@ -1499,7 +1500,7 @@
    "outputs": [
     {
      "ename": "AssertionError",
-     "evalue": "==:\nMissing required field: dogname\nNone",
+     "evalue": "==:\n\nNone",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
@@ -1508,7 +1509,7 @@
       "Cell \u001b[0;32mIn[66], line 3\u001b[0m, in \u001b[0;36mtest_r\u001b[0;34m(cli, path, exp, meth, hx, **kwargs)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_r\u001b[39m(cli, path, exp, meth\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mget\u001b[39m\u001b[38;5;124m'\u001b[39m, hx\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m      2\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m hx: kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mheaders\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mhx-request\u001b[39m\u001b[38;5;124m'\u001b[39m:\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m1\u001b[39m\u001b[38;5;124m\"\u001b[39m}\n\u001b[0;32m----> 3\u001b[0m     \u001b[43mtest_eq\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mcli\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmeth\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtext\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexp\u001b[49m\u001b[43m)\u001b[49m\n",
       "File \u001b[0;32m~/.virtualenvs/fasthtml/lib/python3.10/site-packages/fastcore-1.5.51-py3.10.egg/fastcore/test.py:37\u001b[0m, in \u001b[0;36mtest_eq\u001b[0;34m(a, b)\u001b[0m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_eq\u001b[39m(a,b):\n\u001b[1;32m     36\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`test` that `a==b`\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 37\u001b[0m     \u001b[43mtest\u001b[49m\u001b[43m(\u001b[49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\u001b[43mb\u001b[49m\u001b[43m,\u001b[49m\u001b[43mequals\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m==\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
       "File \u001b[0;32m~/.virtualenvs/fasthtml/lib/python3.10/site-packages/fastcore-1.5.51-py3.10.egg/fastcore/test.py:27\u001b[0m, in \u001b[0;36mtest\u001b[0;34m(a, b, cmp, cname)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     26\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m cname \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m: cname\u001b[38;5;241m=\u001b[39mcmp\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m---> 27\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m cmp(a,b),\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00ma\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mb\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: ==:\nMissing required field: dogname\nNone"
+      "\u001b[0;31mAssertionError\u001b[0m: ==:\n\nNone"
      ]
     }
    ],
@@ -1731,6 +1732,14 @@
     "#|hide\n",
     "import nbdev; nbdev.nbdev_export()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad334807",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -662,10 +662,10 @@
     "    if res is empty or res is None:\n",
     "        frm = await req.form()\n",
     "        res = _formitem(frm, arg)\n",
-    "    # Use default param if needed\n",
+    "    # Raise 400 error if the param does not include a default\n",
+    "    if (res is empty or res is None) and p.default is empty: raise HTTPException(400, f\"Missing required field: {arg}\")\n",
+    "    # If we have a default, return that if we have no value\n",
     "    if res is empty or res is None: res = p.default\n",
-    "    # Raise 400 error if the param is wrong\n",
-    "    if res is Parameter.empty: raise HTTPException(400, f\"Missing required field: {arg}\")\n",
     "    # We can cast str and list[str] to types; otherwise just return what we have\n",
     "    if not isinstance(res, (list,str)) or anno is empty: return res\n",
     "    anno = _fix_anno(anno)\n",
@@ -824,7 +824,7 @@
     "                    if is_async_callable(bf): resp = await resp\n",
     "        if not resp:\n",
     "            wreq = await _wrap_req(req, params)\n",
-    "            resp = f(*wreq)                            \n",
+    "            resp = f(*wreq)\n",
     "            if is_async_callable(f): resp = await resp\n",
     "        for a in after:\n",
     "            _,*wreq = await _wrap_req(req, signature(a).parameters)\n",
@@ -1473,7 +1473,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Working post request\n",
+    "# Working post request, this is our control\n",
     "test_r(cli, '/profile/me', 'Alexis', 'post',\n",
     "       data={'username' : 'Alexis'})"
    ]
@@ -1485,11 +1485,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # Failing post request due to missing required parameter\n",
-    "# try:\n",
-    "#     test_r(cli, '/profile/me', 'Alexis', 'post', data={})\n",
-    "# except AssertionError as e:\n",
-    "#     assert \"Missing required field: username\" in str(e)"
+    "# Failing post request due to missing required username parameter\n",
+    "try:\n",
+    "    test_r(cli, '/profile/me', 'Alexis', 'post', data={})\n",
+    "except AssertionError as e:\n",
+    "    assert \"Missing required field: username\" in str(e)"
    ]
   },
   {
@@ -1497,28 +1497,14 @@
    "execution_count": null,
    "id": "fdb9239c",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "==:\n\nNone",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[75], line 5\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mpet_dog\u001b[39m(dogname: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m): \u001b[38;5;28;01mreturn\u001b[39;00m dogname\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# Working post request with optional parameter\u001b[39;00m\n\u001b[0;32m----> 5\u001b[0m \u001b[43mtest_r\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcli\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m/pet/dog\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mNone\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mpost\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m{\u001b[49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[66], line 3\u001b[0m, in \u001b[0;36mtest_r\u001b[0;34m(cli, path, exp, meth, hx, **kwargs)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_r\u001b[39m(cli, path, exp, meth\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mget\u001b[39m\u001b[38;5;124m'\u001b[39m, hx\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m      2\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m hx: kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mheaders\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mhx-request\u001b[39m\u001b[38;5;124m'\u001b[39m:\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m1\u001b[39m\u001b[38;5;124m\"\u001b[39m}\n\u001b[0;32m----> 3\u001b[0m     \u001b[43mtest_eq\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mcli\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmeth\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtext\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexp\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/.virtualenvs/fasthtml/lib/python3.10/site-packages/fastcore-1.5.51-py3.10.egg/fastcore/test.py:37\u001b[0m, in \u001b[0;36mtest_eq\u001b[0;34m(a, b)\u001b[0m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_eq\u001b[39m(a,b):\n\u001b[1;32m     36\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`test` that `a==b`\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 37\u001b[0m     \u001b[43mtest\u001b[49m\u001b[43m(\u001b[49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\u001b[43mb\u001b[49m\u001b[43m,\u001b[49m\u001b[43mequals\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m==\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/.virtualenvs/fasthtml/lib/python3.10/site-packages/fastcore-1.5.51-py3.10.egg/fastcore/test.py:27\u001b[0m, in \u001b[0;36mtest\u001b[0;34m(a, b, cmp, cname)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     26\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m cname \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m: cname\u001b[38;5;241m=\u001b[39mcmp\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m---> 27\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m cmp(a,b),\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00ma\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mb\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: ==:\n\nNone"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "# Example post request with parameter that has a default value\n",
     "@app.post('/pet/dog')\n",
     "def pet_dog(dogname: str = None): return dogname\n",
     "\n",
     "# Working post request with optional parameter\n",
-    "test_r(cli, '/pet/dog', 'None', 'post', data={})"
+    "test_r(cli, '/pet/dog', '', 'post', data={})"
    ]
   },
   {
@@ -1563,13 +1549,29 @@
    "execution_count": null,
    "id": "48f0a45e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "==:\nNot Found\n{\"a\":1,\"b\":\"foo\",\"nm\":\"me\"}",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[89], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m d \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mdict\u001b[39m(a\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, b\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mfoo\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m----> 3\u001b[0m \u001b[43mtest_r\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcli\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m/bodie/me\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m{\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43ma\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m:1,\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mb\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m:\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfoo\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m,\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mnm\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m:\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mme\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m}\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mpost\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43md\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# This test should not be working, as the \"nm\" arguement isn't provided and there isn't a default\u001b[39;00m\n\u001b[1;32m      5\u001b[0m test_r(cli, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m/bodied/\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m{\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124ma\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m:\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m1\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m,\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mb\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m:\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfoo\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m}\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mpost\u001b[39m\u001b[38;5;124m'\u001b[39m, data\u001b[38;5;241m=\u001b[39md)\n",
+      "Cell \u001b[0;32mIn[66], line 3\u001b[0m, in \u001b[0;36mtest_r\u001b[0;34m(cli, path, exp, meth, hx, **kwargs)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_r\u001b[39m(cli, path, exp, meth\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mget\u001b[39m\u001b[38;5;124m'\u001b[39m, hx\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m      2\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m hx: kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mheaders\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mhx-request\u001b[39m\u001b[38;5;124m'\u001b[39m:\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m1\u001b[39m\u001b[38;5;124m\"\u001b[39m}\n\u001b[0;32m----> 3\u001b[0m     \u001b[43mtest_eq\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mcli\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmeth\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtext\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexp\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.virtualenvs/fasthtml/lib/python3.10/site-packages/fastcore-1.5.51-py3.10.egg/fastcore/test.py:37\u001b[0m, in \u001b[0;36mtest_eq\u001b[0;34m(a, b)\u001b[0m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_eq\u001b[39m(a,b):\n\u001b[1;32m     36\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`test` that `a==b`\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 37\u001b[0m     \u001b[43mtest\u001b[49m\u001b[43m(\u001b[49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\u001b[43mb\u001b[49m\u001b[43m,\u001b[49m\u001b[43mequals\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m==\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.virtualenvs/fasthtml/lib/python3.10/site-packages/fastcore-1.5.51-py3.10.egg/fastcore/test.py:27\u001b[0m, in \u001b[0;36mtest\u001b[0;34m(a, b, cmp, cname)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     26\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m cname \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m: cname\u001b[38;5;241m=\u001b[39mcmp\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m---> 27\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m cmp(a,b),\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00ma\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mb\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: ==:\nNot Found\n{\"a\":1,\"b\":\"foo\",\"nm\":\"me\"}"
+     ]
+    }
+   ],
    "source": [
     "d = dict(a=1, b='foo')\n",
     "\n",
     "test_r(cli, '/bodie/me', '{\"a\":1,\"b\":\"foo\",\"nm\":\"me\"}', 'post', data=d)\n",
-    "# This test should not be working, as the \"nm\" arguement isn't provided and there isn't a default\n",
-    "# test_r(cli, '/bodied/', '{\"a\":\"1\",\"b\":\"foo\"}', 'post', data=d)\n",
+    "# This test should not be working, as the \"nm\" arguement isn't\n",
+    "# provided and there isn't a default\n",
+    "test_r(cli, '/bodied/', '{\"a\":\"1\",\"b\":\"foo\"}', 'post', data=d)\n",
     "test_r(cli, '/bodie2/', 'a: 1; b: foo', 'post', data={'a':1})\n",
     "test_r(cli, '/bodient/', '{\"a\":\"1\",\"b\":\"foo\"}', 'post', data=d)\n",
     "test_r(cli, '/bodietd/', '{\"a\":1,\"b\":\"foo\"}', 'post', data=d)"
@@ -1594,7 +1596,25 @@
    "execution_count": null,
    "id": "cbdcbe74",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Cookie was set at time 23:41:43.695239'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "print(cli.get('/setcookie').text)\n",
     "time.sleep(0.01)\n",
@@ -1623,7 +1643,25 @@
    "execution_count": null,
    "id": "d872ef1c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Set to 2024-07-17 23:41:43.724183\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Session time: 23:41:43.724183'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "print(cli.get('/setsess').text)\n",
     "time.sleep(0.01)\n",
@@ -1635,7 +1673,23 @@
    "execution_count": null,
    "id": "4121c4ab",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# Release notes\n",
+      "\n",
+      "<!-- do not remove -->\n",
+      "\n",
+      "## 0.1.6\n",
+      "\n",
+      "### New Features\n",
+      "\n",
+      "- `File` fu\n"
+     ]
+    }
+   ],
    "source": [
     "@rt(\"/upload\")\n",
     "async def post(uploadfile:str): return (await uploadfile.read()).decode()\n",
@@ -1732,14 +1786,6 @@
     "#|hide\n",
     "import nbdev; nbdev.nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ad334807",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
For #51

TODOs:
- [x] Work with defaults set for params `def my_view(slug: str = None)`
- [ ] Use `test_fail` instead of a try/except block. 
- [ ] Fix or discuss failing test on `bodied` view, see image below in the "Failing Test item" block

## Tests 

<img width="553" alt="Screenshot 2024-07-17 at 23 55 20" src="https://github.com/user-attachments/assets/ea52d45f-a440-4884-a05b-99e15ad6b9d8">


## Failing test item

<img width="661" alt="Screenshot 2024-07-17 at 23 46 25" src="https://github.com/user-attachments/assets/ace8dd85-d0d3-461b-9a0d-a5867c7f74f8">

### When the test is uncommented here is the error it now generates

<img width="769" alt="Screenshot 2024-07-17 at 23 57 02" src="https://github.com/user-attachments/assets/0776d53f-7ac4-4683-90a0-2cc61ef6fe67">

 
