### PR TITLE
Updated html2xt to use unpacked dicts when attr keys are not valid python names

### DIFF
--- a/fasthtml/components.py
+++ b/fasthtml/components.py
@@ -120,6 +120,7 @@ def __getattr__(tag):
     return _f
 
 # %% ../nbs/01_components.ipynb 24
+_re_h2x_attr_key = re.compile(r'^[A-Za-z_-][\w-]*$')
 def html2xt(html):
     rev_map = {'class': 'cls', 'for': 'fr'}
     
@@ -134,7 +135,8 @@ def html2xt(html):
         attrs = []
         for key, value in sorted(elm.attrs.items(), key=lambda x: x[0]=='class'):
             if isinstance(value,(tuple,list)): value = " ".join(value)
-            attrs.append(f'{rev_map.get(key, key).replace("-", "_")}={value!r}')
+            key = rev_map.get(key, key)
+            attrs.append(f'{key.replace("-", "_")}={value!r}' if _re_h2x_attr_key.match(key) else f'**{{{key!r}:{value!r}}}')
         spc = " "*lvl*indent
         onlychild = not cts or (len(cts)==1 and isinstance(cts[0],str))
         j = ', ' if onlychild else f',\n{spc}'

--- a/nbs/01_components.ipynb
+++ b/nbs/01_components.ipynb
@@ -454,6 +454,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
+    "_re_h2x_attr_key = re.compile(r'^[A-Za-z_-][\\w-]*$')\n",
     "def html2xt(html):\n",
     "    rev_map = {'class': 'cls', 'for': 'fr'}\n",
     "    \n",
@@ -468,7 +469,8 @@
     "        attrs = []\n",
     "        for key, value in sorted(elm.attrs.items(), key=lambda x: x[0]=='class'):\n",
     "            if isinstance(value,(tuple,list)): value = \" \".join(value)\n",
-    "            attrs.append(f'{rev_map.get(key, key).replace(\"-\", \"_\")}={value!r}')\n",
+    "            key = rev_map.get(key, key)\n",
+    "            attrs.append(f'{key.replace(\"-\", \"_\")}={value!r}' if _re_h2x_attr_key.match(key) else f'**{{{key!r}:{value!r}}}')\n",
     "        spc = \" \"*lvl*indent\n",
     "        onlychild = not cts or (len(cts)==1 and isinstance(cts[0],str))\n",
     "        j = ', ' if onlychild else f',\\n{spc}'\n",

--- a/nbs/06_explaining_components.ipynb
+++ b/nbs/06_explaining_components.ipynb
@@ -181,7 +181,8 @@
     "    Option(\"one\", value=\"1\", selected=True), # <1>\n",
     "    Option(\"two\", value=\"2\", selected=False), # <2>\n",
     "    Option(\"three\", value=3),  # <3>\n",
-    "    cls=\"selector\"  # <4>\n",
+    "    cls=\"selector\",  # <4>\n",
+    "    **{'@click':\"alert('Clicked');\"} # <5>\n",
     ")\n",
     "```\n",
     "\n",
@@ -189,6 +190,7 @@
     "2. On line 3, we demonstration that attributes set to the `boolean` value of `False` do not appear in the rendered output\n",
     "3. On line 4 is an example of how integers and other non-string values are in the rendered output are converted to strings \n",
     "4. On line 5 we set the HTML class using the `cls` argument. We use `cls` here as `class` is a reserved word in Python. During the rendering process this will be converted to the word \"class\"\n",
+    "5. On line 6 we have an attribute name that cannot be represented as a python variable. We can use an unpacked `dict` in these cases to represent these values.\n",
     "\n",
     "This renders the following HTML snippet:"
    ]
@@ -202,7 +204,7 @@
      "data": {
       "text/markdown": [
        "```xml\n",
-       "<select class=\"selector\">\n",
+       "<select @click=\"alert(&#x27;Clicked&#x27;);\" class=\"selector\">\n",
        "  <option value=\"1\" selected>one</option>\n",
        "  <option value=\"2\" >two</option>\n",
        "  <option value=\"3\">three</option>\n",
@@ -215,7 +217,7 @@
        " (['option', ('one',), {'value': '1', 'selected': True}],\n",
        "  ['option', ('two',), {'value': '2', 'selected': False}],\n",
        "  ['option', ('three',), {'value': 3}]),\n",
-       " {'class': 'selector'}]"
+       " {'@click': \"alert('Clicked');\", 'class': 'selector'}]"
       ]
      },
      "execution_count": null,
@@ -229,7 +231,8 @@
     "    Option(\"one\", value=\"1\", selected=True), # <1>\n",
     "    Option(\"two\", value=\"2\", selected=False), # <2>\n",
     "    Option(\"three\", value=3),  # <3>\n",
-    "    cls=\"selector\" # <4>\n",
+    "    cls=\"selector\",  # <4>\n",
+    "    **{'@click':\"alert('Clicked');\"} # <5>\n",
     ")"
    ]
   }
@@ -242,5 +245,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Updated html2xt to use unpacked dicts when attr keys are not valid python names.

Also added example of using an unpacked dict to the explaining components nb.


Minimal Example:
```python
hl_md(html2xt_new('<div x-data="{open: false}" x-init="console.log(\'Initialized\')" @click="open = !open">Toggle</div>'))
```
to
```python
Div('Toggle', x_data='{open: false}', x_init="console.log('Initialized')", **{'@click':'open = !open'})
```