### PR TITLE
Sidebar sections patterned after nbdev

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 520,
+   "execution_count": null,
    "id": "32849494",
    "metadata": {},
    "outputs": [],
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 521,
+   "execution_count": null,
    "id": "8394fbde",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 522,
+   "execution_count": null,
    "id": "7f5d0a72",
    "metadata": {},
    "outputs": [],
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 523,
+   "execution_count": null,
    "id": "19d3f2a7",
    "metadata": {},
    "outputs": [],
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 524,
+   "execution_count": null,
    "id": "515d6666",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 525,
+   "execution_count": null,
    "id": "652e96fa",
    "metadata": {},
    "outputs": [],
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 526,
+   "execution_count": null,
    "id": "ac88a10b",
    "metadata": {},
    "outputs": [],
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 527,
+   "execution_count": null,
    "id": "e68a76c9",
    "metadata": {},
    "outputs": [],
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 528,
+   "execution_count": null,
    "id": "5331a3e7",
    "metadata": {},
    "outputs": [
@@ -158,7 +158,7 @@
        "datetime.datetime(2024, 7, 20, 14, 0)"
       ]
      },
-     "execution_count": 528,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 529,
+   "execution_count": null,
    "id": "7c820373",
    "metadata": {},
    "outputs": [],
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 530,
+   "execution_count": null,
    "id": "442a5aac",
    "metadata": {},
    "outputs": [
@@ -193,7 +193,7 @@
        "'Snake-Case'"
       ]
      },
-     "execution_count": 530,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -204,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 531,
+   "execution_count": null,
    "id": "25f3b8f8",
    "metadata": {},
    "outputs": [],
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 532,
+   "execution_count": null,
    "id": "5b4b5d95",
    "metadata": {},
    "outputs": [],
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 533,
+   "execution_count": null,
    "id": "36e2cac0",
    "metadata": {},
    "outputs": [
@@ -265,7 +265,7 @@
        "HtmxHeaders(boosted=None, current_url=None, history_restore_request=None, prompt=None, request='1', target=None, trigger_name=None, trigger=None)"
       ]
      },
-     "execution_count": 533,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 534,
+   "execution_count": null,
    "id": "edbc8d46",
    "metadata": {},
    "outputs": [],
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 535,
+   "execution_count": null,
    "id": "e68fead1",
    "metadata": {},
    "outputs": [
@@ -303,7 +303,7 @@
        "(1, 0)"
       ]
      },
-     "execution_count": 535,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 536,
+   "execution_count": null,
    "id": "1d53e8e7",
    "metadata": {},
    "outputs": [],
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 537,
+   "execution_count": null,
    "id": "0afb520c",
    "metadata": {},
    "outputs": [],
@@ -351,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 538,
+   "execution_count": null,
    "id": "95b1f5c9",
    "metadata": {},
    "outputs": [
@@ -361,7 +361,7 @@
        "(str, float)"
       ]
      },
-     "execution_count": 538,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -372,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 539,
+   "execution_count": null,
    "id": "1dbe4780",
    "metadata": {},
    "outputs": [
@@ -382,7 +382,7 @@
        "1"
       ]
      },
-     "execution_count": 539,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -393,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 540,
+   "execution_count": null,
    "id": "a4405165",
    "metadata": {},
    "outputs": [
@@ -403,7 +403,7 @@
        "[1, 2]"
       ]
      },
-     "execution_count": 540,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -414,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 541,
+   "execution_count": null,
    "id": "a9331734",
    "metadata": {},
    "outputs": [
@@ -424,7 +424,7 @@
        "[1]"
       ]
      },
-     "execution_count": 541,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -435,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 542,
+   "execution_count": null,
    "id": "c58ccadb",
    "metadata": {},
    "outputs": [],
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 543,
+   "execution_count": null,
    "id": "59757d76",
    "metadata": {},
    "outputs": [
@@ -462,7 +462,7 @@
        "1"
       ]
      },
-     "execution_count": 543,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -474,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 544,
+   "execution_count": null,
    "id": "50455eb8",
    "metadata": {},
    "outputs": [
@@ -484,7 +484,7 @@
        "[1]"
       ]
      },
-     "execution_count": 544,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -495,7 +495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 545,
+   "execution_count": null,
    "id": "136175ad",
    "metadata": {},
    "outputs": [
@@ -505,7 +505,7 @@
        "[1, 2]"
       ]
      },
-     "execution_count": 545,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -516,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 546,
+   "execution_count": null,
    "id": "5fc04751",
    "metadata": {},
    "outputs": [],
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 547,
+   "execution_count": null,
    "id": "56cc589f",
    "metadata": {},
    "outputs": [],
@@ -542,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 548,
+   "execution_count": null,
    "id": "cb4ed4aa",
    "metadata": {},
    "outputs": [],
@@ -553,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 549,
+   "execution_count": null,
    "id": "ffdde66f",
    "metadata": {},
    "outputs": [],
@@ -567,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 550,
+   "execution_count": null,
    "id": "5fe74444",
    "metadata": {},
    "outputs": [],
@@ -580,7 +580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 551,
+   "execution_count": null,
    "id": "cf80ea34",
    "metadata": {},
    "outputs": [],
@@ -594,7 +594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 552,
+   "execution_count": null,
    "id": "0b6ac588",
    "metadata": {},
    "outputs": [],
@@ -611,7 +611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 553,
+   "execution_count": null,
    "id": "2a8b10f4",
    "metadata": {},
    "outputs": [
@@ -640,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 554,
+   "execution_count": null,
    "id": "6775cbf8",
    "metadata": {},
    "outputs": [],
@@ -688,7 +688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 555,
+   "execution_count": null,
    "id": "bf945ee8",
    "metadata": {},
    "outputs": [
@@ -696,7 +696,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[<starlette.requests.Request object at 0x108ec7af0>, <starlette.applications.Starlette object at 0x108c22c80>, '1', HttpHeader(k='value1', v=\"['value2', 'value3']\")]\n"
+      "[<starlette.requests.Request object>, <starlette.applications.Starlette object>, '1', HttpHeader(k='value1', v=\"['value2', 'value3']\")]\n"
      ]
     }
    ],
@@ -716,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 556,
+   "execution_count": null,
    "id": "7a661bfa",
    "metadata": {},
    "outputs": [],
@@ -733,7 +733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 557,
+   "execution_count": null,
    "id": "2ee5adf1",
    "metadata": {},
    "outputs": [
@@ -743,7 +743,7 @@
        "[['a', 1, {}], ['a', 1, {}], ['a', 1, {}], ['a', 1, {}]]"
       ]
      },
-     "execution_count": 557,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -755,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 558,
+   "execution_count": null,
    "id": "527b6730",
    "metadata": {},
    "outputs": [],
@@ -775,7 +775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 559,
+   "execution_count": null,
    "id": "e83f0e64",
    "metadata": {},
    "outputs": [],
@@ -798,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 560,
+   "execution_count": null,
    "id": "aacff5ac",
    "metadata": {},
    "outputs": [],
@@ -810,7 +810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 561,
+   "execution_count": null,
    "id": "df10cbba",
    "metadata": {},
    "outputs": [],
@@ -855,7 +855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 562,
+   "execution_count": null,
    "id": "f2277c02",
    "metadata": {},
    "outputs": [],
@@ -889,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 563,
+   "execution_count": null,
    "id": "dcc15129",
    "metadata": {},
    "outputs": [],
@@ -924,7 +924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 564,
+   "execution_count": null,
    "id": "983bcfe2",
    "metadata": {},
    "outputs": [],
@@ -950,7 +950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 565,
+   "execution_count": null,
    "id": "b89130cd",
    "metadata": {},
    "outputs": [],
@@ -964,7 +964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 566,
+   "execution_count": null,
    "id": "541cfa0a",
    "metadata": {},
    "outputs": [],
@@ -979,7 +979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 567,
+   "execution_count": null,
    "id": "e83fc876",
    "metadata": {},
    "outputs": [],
@@ -1004,7 +1004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 568,
+   "execution_count": null,
    "id": "fb97d46b",
    "metadata": {},
    "outputs": [],
@@ -1020,7 +1020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 569,
+   "execution_count": null,
    "id": "8bd78eeb",
    "metadata": {},
    "outputs": [],
@@ -1037,7 +1037,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 570,
+   "execution_count": null,
    "id": "4771838e",
    "metadata": {},
    "outputs": [
@@ -1047,7 +1047,7 @@
        "'2c25d03b-24f2-4946-833a-50ac832a1576'"
       ]
      },
-     "execution_count": 570,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1058,7 +1058,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 571,
+   "execution_count": null,
    "id": "042666e2",
    "metadata": {},
    "outputs": [],
@@ -1069,7 +1069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 572,
+   "execution_count": null,
    "id": "be1f64a6",
    "metadata": {},
    "outputs": [],
@@ -1122,7 +1122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 573,
+   "execution_count": null,
    "id": "402ec641",
    "metadata": {},
    "outputs": [],
@@ -1148,7 +1148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 574,
+   "execution_count": null,
    "id": "91c223f9",
    "metadata": {},
    "outputs": [],
@@ -1161,7 +1161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 575,
+   "execution_count": null,
    "id": "3d252538",
    "metadata": {},
    "outputs": [],
@@ -1174,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 576,
+   "execution_count": null,
    "id": "0b727f38",
    "metadata": {},
    "outputs": [],
@@ -1198,7 +1198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 577,
+   "execution_count": null,
    "id": "9abc3781",
    "metadata": {},
    "outputs": [],
@@ -1208,7 +1208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 578,
+   "execution_count": null,
    "id": "645d8d95",
    "metadata": {},
    "outputs": [],
@@ -1218,7 +1218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 579,
+   "execution_count": null,
    "id": "3edc4781",
    "metadata": {},
    "outputs": [
@@ -1228,7 +1228,7 @@
        "'Hi there'"
       ]
      },
-     "execution_count": 579,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1243,7 +1243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 580,
+   "execution_count": null,
    "id": "07fe773b",
    "metadata": {},
    "outputs": [
@@ -1253,7 +1253,7 @@
        "'Postal'"
       ]
      },
-     "execution_count": 580,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1267,7 +1267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 581,
+   "execution_count": null,
    "id": "bb4f8b67",
    "metadata": {},
    "outputs": [
@@ -1277,7 +1277,7 @@
        "'testserver'"
       ]
      },
-     "execution_count": 581,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1291,7 +1291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 582,
+   "execution_count": null,
    "id": "64343367",
    "metadata": {},
    "outputs": [
@@ -1301,7 +1301,7 @@
        "'Good day to you, Alexis!'"
       ]
      },
-     "execution_count": 582,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1315,7 +1315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 583,
+   "execution_count": null,
    "id": "db0281cf",
    "metadata": {},
    "outputs": [],
@@ -1325,7 +1325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 584,
+   "execution_count": null,
    "id": "b827960a",
    "metadata": {},
    "outputs": [],
@@ -1355,7 +1355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 585,
+   "execution_count": null,
    "id": "6b022adb",
    "metadata": {},
    "outputs": [],
@@ -1371,7 +1371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 586,
+   "execution_count": null,
    "id": "0bfd7af6",
    "metadata": {},
    "outputs": [],
@@ -1396,7 +1396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 587,
+   "execution_count": null,
    "id": "52d9a3f2",
    "metadata": {},
    "outputs": [],
@@ -1412,7 +1412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 588,
+   "execution_count": null,
    "id": "b8be4ef3",
    "metadata": {},
    "outputs": [],
@@ -1441,7 +1441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 589,
+   "execution_count": null,
    "id": "5f045cf9",
    "metadata": {},
    "outputs": [],
@@ -1458,7 +1458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 590,
+   "execution_count": null,
    "id": "52f9f934",
    "metadata": {},
    "outputs": [],
@@ -1470,7 +1470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 591,
+   "execution_count": null,
    "id": "a3596991",
    "metadata": {},
    "outputs": [],
@@ -1484,7 +1484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 592,
+   "execution_count": null,
    "id": "fdb9239c",
    "metadata": {},
    "outputs": [],
@@ -1499,7 +1499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 593,
+   "execution_count": null,
    "id": "3366d88f",
    "metadata": {},
    "outputs": [],
@@ -1536,7 +1536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 594,
+   "execution_count": null,
    "id": "48f0a45e",
    "metadata": {},
    "outputs": [],
@@ -1552,7 +1552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 595,
+   "execution_count": null,
    "id": "8057b34b",
    "metadata": {},
    "outputs": [],
@@ -1566,7 +1566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 596,
+   "execution_count": null,
    "id": "cbdcbe74",
    "metadata": {},
    "outputs": [
@@ -1583,7 +1583,7 @@
        "'Cookie was set at time 18:27:31.343819'"
       ]
      },
-     "execution_count": 596,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1596,7 +1596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 597,
+   "execution_count": null,
    "id": "5bce33f0",
    "metadata": {},
    "outputs": [],
@@ -1613,7 +1613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 598,
+   "execution_count": null,
    "id": "d872ef1c",
    "metadata": {},
    "outputs": [
@@ -1630,7 +1630,7 @@
        "'Session time: 18:27:31.368913'"
       ]
      },
-     "execution_count": 598,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1643,7 +1643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 599,
+   "execution_count": null,
    "id": "4121c4ab",
    "metadata": {},
    "outputs": [
@@ -1675,7 +1675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 600,
+   "execution_count": null,
    "id": "e4fc13b0",
    "metadata": {},
    "outputs": [],
@@ -1685,7 +1685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 601,
+   "execution_count": null,
    "id": "90341316",
    "metadata": {},
    "outputs": [],
@@ -1702,7 +1702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 602,
+   "execution_count": null,
    "id": "97f2553c",
    "metadata": {},
    "outputs": [],
@@ -1712,7 +1712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 603,
+   "execution_count": null,
    "id": "f26a6377",
    "metadata": {},
    "outputs": [],
@@ -1722,7 +1722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 604,
+   "execution_count": null,
    "id": "fa194d53",
    "metadata": {},
    "outputs": [],
@@ -1751,7 +1751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 605,
+   "execution_count": null,
    "id": "d211e8e2",
    "metadata": {},
    "outputs": [],

--- a/nbs/06_explaining_components.ipynb
+++ b/nbs/06_explaining_components.ipynb
@@ -242,10 +242,6 @@
    "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -20,5 +20,21 @@ website:
     search: true
   sidebar:
     style: floating
+    contents:
+      - index.ipynb
+      - section: Tutorials
+        contents:
+          - 05_by_example.ipynb
+      - section: Explanations
+        contents:
+          - 06_explaining_components.ipynb
+      - section: API
+        contents:
+          - 00_core.ipynb
+          - 01_components.ipynb
+          - 02_xtend.ipynb
+          - 03_oauth.ipynb
+          - 04_cli.ipynb
+      
 
-metadata-files: [nbdev.yml, sidebar.yml]
+metadata-files: [nbdev.yml]


### PR DESCRIPTION
Authored by @audreyfeldroy, @pydanny is the typist.

This PR organizes the FastHTML sidebar into three sections mirroring the nbdev sidebar structure:

- Tutorials
- Explanations
- API

This will make it easier for contributors to know where to put these efforts:

<img width="724" alt="Screenshot 2024-07-20 at 22 15 11" src="https://github.com/user-attachments/assets/5c3e9ee9-2414-46ff-87c2-f82c901a940d">
