### PR TITLE
Early draft of a FH tutorial for LLMs

### DIFF
--- a/nbs/07_fh_for_llms.ipynb
+++ b/nbs/07_fh_for_llms.ipynb
@@ -1,0 +1,278 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FastHTML for LLMs\n",
+    "\n",
+    "This tutorial is written for a primary target audience of LLMs who want to generate Python web apps with the new FastHTML web framework by Jeremy Howard. It assumes that you are an AI assistant with deep LLM-level knowledge of web development.\n",
+    "\n",
+    "Experienced developers may find this tutorial useful, though it deliberately skips over the concepts that are assumed to be known by LLMs.\n",
+    "\n",
+    "## Pre-requisites\n",
+    "\n",
+    "Human Tip: Before you give this to your LLM, give it the latest versions of the code and docs for FastHTML, fastcore, Starlette, and HTMX.\n",
+    "\n",
+    "## Framework Overview\n",
+    "\n",
+    "FastHTML is a web framework designed to make it easy for LLMs to generate full-featured web apps. Web apps are written entirely in Python, with no other file types required. \n",
+    "\n",
+    "FastHTML is built on top of fastcore, Starlette, and HTMX.\n",
+    "\n",
+    "Key features:\n",
+    "\n",
+    "- No templating: all HTML is generated from Python code\n",
+    "- Minimal JavaScript: FastHTML aims to handle as much interactivity as possible with HTMX attributes on HTML tags\n",
+    "- Functions over classes: components are preferably written as functions, though classes are also supported\n",
+    "- Extremely compact code: FastHTML is designed to create 1-file web apps under 500 lines of code\n",
+    "\n",
+    "## Installation\n",
+    "\n",
+    "`pip install python-fasthtml`\n",
+    "\n",
+    "## Hello World\n",
+    "\n",
+    "The simplest FastHTML app is a main.py containing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fasthtml.common import *\n",
+    "\n",
+    "app = FastHTML()\n",
+    "\n",
+    "@app.get(\"/\")\n",
+    "def home():\n",
+    "    return H1(\"Hello, World!\")\n",
+    "\n",
+    "# TODO: figure out right way to call run_uv() so the user can run `python main.py` and not have to know about uvicorn\n",
+    "# And check that it deploys to Railway"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run it:\n",
+    "\n",
+    "```bash\n",
+    "$ uvicorn main:app --reload\n",
+    "INFO:     Will watch for changes in these directories: ['/Users/a/code/answerai-repos/my-fhbe-walkthrough']\n",
+    "INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)\n",
+    "INFO:     Started reloader process [30966] using WatchFiles\n",
+    "INFO:     Started server process [30968]\n",
+    "INFO:     Waiting for application startup.\n",
+    "INFO:     Application startup complete.\n",
+    "INFO:     127.0.0.1:56539 - \"GET / HTTP/1.1\" 200 OK\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The simplest components are functions like H1(), H2(), P(), Div(), etc. Pass a string into H1() to get a `<h1>` tag containing that string:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```xml\n",
+       "<h1>Hello, World!</h1>\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "['h1', ('Hello, World!',), {}]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "H1(\"Hello, World!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These simple components can be nested to create more complex HTML structures:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```xml\n",
+       "<div foo=\"bar\" id=\"main\" class=\"container\">\n",
+       "  <h1>Welcome Home</h1>\n",
+       "  <p>There`s no place like 127.0.0.1</p>\n",
+       "</div>\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "['div',\n",
+       " (['h1', ('Welcome Home',), {}],\n",
+       "  ['p', ('There`s no place like 127.0.0.1',), {}]),\n",
+       " {'foo': 'bar', 'id': 'main', 'class': 'container'}]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Div(H1('Welcome Home'), P('There`s no place like 127.0.0.1'), \n",
+    "                   foo='bar', id='main', cls='container')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the keyword arguments are used to set attributes on the HTML tags.\n",
+    "\n",
+    "Now if we return this nested div from our app, you'll see that we only have to return the div from the `home()` view function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app = FastHTML()\n",
+    "\n",
+    "@app.get(\"/\")\n",
+    "def home():\n",
+    "    return Div(H1('Welcome Home'), P('There`s no place like 127.0.0.1'), \n",
+    "                   foo='bar', id='main', cls='container')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stop here for now - this part needs cleanup\n",
+    "\n",
+    "## TODO: what does the FastHTML router do vs. the Starlette router?\n",
+    "The router wraps the view's return value in a full HTML document. When you send an HTTP GET request to http://127.0.0.1:8000, notice how the HTML returned by `home() is wrapped in a full HTML document:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<!doctype html></!doctype>\n",
+      "\n",
+      "<html>\n",
+      "  <head>\n",
+      "    <title>FastHTML page</title>\n",
+      "    <meta charset=\"utf-8\"></meta>\n",
+      "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\"></meta>\n",
+      "    <script src=\"https://unpkg.com/htmx.org@next/dist/htmx.min.js\"></script>\n",
+      "    <script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@1.3.0/surreal.js\"></script>\n",
+      "    <script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script>\n",
+      "  </head>\n",
+      "  <body>\n",
+      "<div foo=\"bar\" id=\"main\" class=\"container\">\n",
+      "  <h1>Welcome Home</h1>\n",
+      "  <p>There`s no place like 127.0.0.1</p>\n",
+      "</div>\n",
+      "  </body>\n",
+      "</html>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from starlette.testclient import TestClient\n",
+    "client = TestClient(app)\n",
+    "r = client.get(\"/\")\n",
+    "print(r.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deploy\n",
+    "\n",
+    "Run FastHTML's `railway_deploy` command to deploy your app to Railway."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Style Guide\n",
+    "\n",
+    "When writing FastHTML Python code:\n",
+    "\n",
+    "## Components\n",
+    "\n",
+    "Define components as functions decorated with `@delegates`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@delegates(xt_hx, keep=True)\n",
+    "def Card(*c, header=None, footer=None, **kwargs)->XT:\n",
+    "    \"A PicoCSS Card, implemented as an Article with optional Header and Footer\"\n",
+    "    if header: c = (Header(header),) + c\n",
+    "    if footer: c += (Footer(footer),)\n",
+    "    return Article(*c, **kwargs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Use CamelCase for component names even though Python convention is snake_case for functions\n",
+    "* Follow normal HTML attribute conventions for keyword arguments that are turned into HTML attributes\n",
+    "* Don't call `to_xml()` directly; it's called for you by when xt_hx delegates to the component (TODO: I think this may be how it works, but I'm not sure)\n",
+    "\n",
+    "## Web Serving\n",
+    "\n",
+    "* In __main__, call `run_uv() so the user can run the app with `python main.py`"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I thought I'd try writing a tutorial for the LLM audience, aimed at fixing some of the bugs I was finding in code generated by [FastHTML Helper](https://chatgpt.com/g/g-xPqF9SZjM-fasthtml-helper). 

For example: the code generated in https://chatgpt.com/share/5fbeffcb-73e4-4e4c-a808-44229e2dd37f could be a bit more in the style of 02_xtend.ipynb.

This began as heavy edits to 05_by_example.ipynb, but my changes were becoming rather invasive. I felt a bit uneasy restructuring or stripping out the LLM-known concepts as much of that is good for humans.

General feedback on the approach? Corrections? Forgive the TODOs and all my mistakes, I still don't know much 😅 