### PR TITLE
fixed uploadFile type hinting

### DIFF
--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -77,7 +77,8 @@
     "\n",
     "from fastcore.test import *\n",
     "from starlette.testclient import TestClient\n",
-    "from starlette.requests import Headers"
+    "from starlette.requests import Headers\n",
+    "from starlette.datastructures import UploadFile"
    ]
   },
   {
@@ -1643,7 +1644,7 @@
    ],
    "source": [
     "@rt(\"/upload\")\n",
-    "async def post(uploadfile:str): return (await uploadfile.read()).decode()\n",
+    "async def post(uploadfile:UploadFile): return (await uploadfile.read()).decode()\n",
     "\n",
     "fn = '../../CHANGELOG.md'\n",
     "data = {'message': 'Hello, world!'}\n",


### PR DESCRIPTION
The correct type of files on `post` paths is `UploadFile`. I changed it in the PR. 

However, my main issue is that correct file upload requires to set encoding `enctype="multipart/form-data"` and this is not mentioned anywhere. If you don't set it, the request file will passed as a string and contains `[Object file]`. Having the documentation show that string is indeed the correct type (when it's not) just makes it a bit more confusing.

I would lvoe to add this information somewhere so other people can see but I'm unsure where it'd be appropriate. This is a minimal example of what needs to be done for correct file uploads. The relevant bit is:

`enctype="multipart/form-data"` #   <---- without this the file is passed as a string and contains '[Object file]'


```
from fasthtml.common import *
import os
import uuid

app = FastHTML(hdrs=(picolink))
rt = app.route


@rt("/")
async def get(request):
    add = Form(
        Input(id="new-file", name="file", type="file", required=True),
        Button("Add"),
        hx_post="/",
        hx_swap="beforeend",
        enctype="multipart/form-data" #   <---- without this the file is passed as a string and contains '[Object file]'
    ) 
    return add

@rt("/")
async def post(request):
    form = await request.form()
    file = form.get('file')
    content = await file.read()
    filename = f"file_{uuid.uuid4()}{os.path.splitext(file.filename)[1]}"
    with open(filename, 'wb') as f:
        f.write(content)

    return "Upload OK"

serve()
```