### PR TITLE
changes toast names to avoid conflict with bootstrap

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -2,24 +2,24 @@ from fasthtml.core import *
 from fasthtml.components import *
 from fasthtml.xtend import *
 
-tcid = 'toast-container'
+tcid = 'fh-toast-container'
 sk = "toasts"
 toast_css = """
-.toast-container {
+.fh-toast-container {
     position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000;
     display: flex; flex-direction: column; align-items: center; width: 100%;
     pointer-events: none; opacity: 0; transition: opacity 0.3s ease-in-out;
 }
-.toast {
+.fh-toast {
     background-color: #333; color: white;
     padding: 12px 20px; border-radius: 4px; margin-bottom: 10px;
     max-width: 80%; width: auto; text-align: center;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
-.toast-info { background-color: #2196F3; }
-.toast-success { background-color: #4CAF50; }
-.toast-warning { background-color: #FF9800; }
-.toast-error { background-color: #F44336; }
+.fh-toast-info { background-color: #2196F3; }
+.fh-toast-success { background-color: #4CAF50; }
+.fh-toast-warning { background-color: #FF9800; }
+.fh-toast-error { background-color: #F44336; }
 """
 
 toast_js = """
@@ -30,7 +30,7 @@ export function proc_htmx(sel, func) {
     elements.forEach(func);
   });
 }
-proc_htmx('.toast-container', async function(toast) {
+proc_htmx('.fh-toast-container', async function(toast) {
     await sleep(100);
     toast.style.opacity = '0.8';
     await sleep(3000);
@@ -45,8 +45,8 @@ def add_toast(sess, message, typ="info"):
     sess.setdefault(sk, []).append((message, typ))
 
 def render_toasts(sess):
-    toasts = [Div(msg, cls=f"toast toast-{typ}") for msg,typ in sess.pop(sk, [])]
-    return Div(Div(*toasts, cls="toast-container"),
+    toasts = [Div(msg, cls=f"fh-toast fh-toast-{typ}") for msg,typ in sess.pop(sk, [])]
+    return Div(Div(*toasts, cls="fh-toast-container"),
                hx_swap_oob="afterbegin:body")
 
 def toast_after(resp, req, sess):


### PR DESCRIPTION
See #132 

The `.toast` class of FastHTML (`setup_toasts()`) seems to be in conflict with the `.toast` class of bootstrap. 

Since Bootstrap is still very popular, it might be a good idea to namespace the class names to `.fh-toasts` etc. 

(I didn't run the nbdev commands, since the `toaster.py` doesn't seem to be created with nbdev. If that's wrong, I will change the pull request). 