### PR TITLE
Fix typos and rewording for clarity in 'Explanations' section.

### DIFF
--- a/nbs/explains/explaining_xt_components.ipynb
+++ b/nbs/explains/explaining_xt_components.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**ft**, or 'FastTags', are the display components of FastHTML. In fact, the word \"components\" in the context of FastHTML is often synonymous with ft. \n",
+    "**ft**, or 'FastTags', are the display components of FastHTML. In fact, the word \"components\" in the context of FastHTML is often synonymous with **ft**. \n",
     "\n",
     "For example, when we look at a FastHTML app, in particular the views, as well as various functions and other objects, we see something like the code snippet below. It's the `return` statement that we want to pay attention to:"
    ]
@@ -211,14 +211,14 @@
     ")\n",
     "```\n",
     "\n",
-    "1. Line 1 demonstrates that FastHTML appreciates Labels surrounding their fields. \n",
-    "2. On line 4, we can see that attributes set to the `boolean` value of `True` are rendered with just the name of the attribute\n",
-    "3. On line 5, we demonstration that attributes set to the `boolean` value of `False` do not appear in the rendered output\n",
-    "4. On line 6 is an example of how integers and other non-string values are in the rendered output are converted to strings \n",
-    "5. Line 7 is where we set the HTML class using the `cls` argument. We use `cls` here as `class` is a reserved word in Python. During the rendering process this will be converted to the word \"class\"\n",
-    "6. Line 9 demonstrates that any named argument passed into an ft component will have the leading underscore stripped away before rendering. Useful for handling reserved words in Python\n",
-    "7. On line 10 we have an attribute name that cannot be represented as a python variable. We can use an unpacked `dict` in these cases to represent these values.\n",
-    "8. The use of `_for` on line 12 is another demonstrated of an argument having the leading underscore stripped during render. We can also use `fr` as that will be expanded to `for`.\n",
+    "1. Line 1 demonstrates that FastHTML appreciates `Label`s surrounding their fields. \n",
+    "2. On line 5, we can see that attributes set to the `boolean` value of `True` are rendered with just the name of the attribute. \n",
+    "3. On line 6, we demonstrate that attributes set to the `boolean` value of `False` do not appear in the rendered output. \n",
+    "4. Line 7 is an example of how integers and other non-string values in the rendered output are converted to strings. \n",
+    "5. Line 8 is where we set the HTML class using the `cls` argument. We use `cls` here as `class` is a reserved word in Python. During the rendering process this will be converted to the word \"class\". \n",
+    "6. Line 9 demonstrates that any named argument passed into an ft component will have the leading underscore stripped away before rendering. Useful for handling reserved words in Python. \n",
+    "7. On line 10 we have an attribute name that cannot be represented as a python variable. In cases lie these, we can use an unpacked `dict` to represent these values. \n",
+    "8. The use of `_for` on line 12 is another demonstration of an argument having the leading underscore stripped during render. We can also use `fr` as that will be expanded to `for`.\n",
     "\n",
     "This renders the following HTML snippet:"
    ]

--- a/nbs/explains/routes.ipynb
+++ b/nbs/explains/routes.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Behaviour in FastHTML apps is defined by routes. The syntax is largely the same as the wonderful [FastAPI](https://fastapi.tiangolo.com/) (which is what you should be using instead of this if you're creating a JSON service. FastHTML is for mainly for making HTML web apps, not APIs).\n",
+    "Behaviour in FastHTML apps is defined by routes. The syntax is largely the same as the wonderful [FastAPI](https://fastapi.tiangolo.com/) (which is what you should be using instead of this if you're creating a JSON service. FastHTML is mainly for making HTML web apps, not APIs).\n",
     "\n",
     "Note that you need to include the types of your parameters, so that `FastHTML` knows what to pass to your function. Here, we're just expecting a string:"
    ]
@@ -112,9 +112,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the previous example, the function name (`get_nm`) didn't actually matter -- we could have just called it `_`, for instance, since we never actually call it directly. It's just called through HTTP. In fact, we often do call our functions `_` when using this style of route, since that's one less thing we have to worry about naming.\n",
+    "In the previous example, the function name (`get_nm`) didn't actually matter -- we could have just called it `_`, for instance, since we never actually call it directly. It's just called through HTTP. In fact, we often do call our functions `_` when using this style of route, since that's one less thing we have to worry about, naming.\n",
     "\n",
-    "An alternative approach to creating a route is to use `app.route` instead, in which case you make the function name the HTTP method you want. Since this is such a common pattern, you might like to give a shorter name to `app.route` -- we normally use `rt`:"
+    "An alternative approach to creating a route is to use `app.route` instead, in which case, you make the function name the HTTP method you want. Since this is such a common pattern, you might like to give a shorter name to `app.route` -- we normally use `rt`:"
    ]
   },
   {


### PR DESCRIPTION
Made some changes to improve readability in the `ft Components` and `Routes` docs.

I believe that working on those typos per section is much more manageable than submitting corrections from all the docs in one single PR.