### PR TITLE
Fixed reloadAttempts variable of JS snippet in live_reload.py

### DIFF
--- a/fasthtml/live_reload.py
+++ b/fasthtml/live_reload.py
@@ -13,7 +13,7 @@ LIVE_RELOAD_SCRIPT = """
             let reloadAttempts = 0;
             const intervalFn = setInterval(function(){
                 window.location.reload();
-                reloadCount++;
+                reloadAttempts++;
                 if (reloadAttempts === maxReloadAttempts) clearInterval(intervalFn);
             }, reloadInterval);
         }


### PR DESCRIPTION
The counter for reload attempts in the JS snippet didn't work, throwing an error in Browser at live reload.