### PR TITLE
move deployment info to fh-deploy

### DIFF
--- a/nbs/tutorials/deployment.ipynb
+++ b/nbs/tutorials/deployment.ipynb
@@ -4,85 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Deploying FastHTML Apps\n",
-    "\n",
-    "> This page provides an introduction to deploying FastHTML apps."
+    "# Deploying FastHTML Apps"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "FastHTML apps can be deployed to a number of platforms. Below are a few suggested options, with more on the way.\n",
-    "\n",
-    "- [Railway](https://railway.app/), documented below\n",
-    "- [Vercel](https://vercel.com/), via [this template](https://vercel.com/templates/python/fasthtml-python-boilerplate)\n",
-    "- [Replit](https://replit.com/), via [this template](https://replit.com/@johnowhitaker/FastHTML-Example?v=1)\n",
-    "- [Hugging Face](https://huggingface.co/), via [fasthtml-hf](https://github.com/AnswerDotAI/fasthtml-hf)\n",
-    "- [PythonAnywhere](https://www.pythonanywhere.com/), following [this guide](https://help.pythonanywhere.com/pages/ASGICommandLine) (not tested yet)\n",
-    "- [Uvicorn](https://www.uvicorn.org), following [this guide](https://www.uvicorn.org/deployment/). This is an advanced topic.\n",
+    "FastHTML apps can be deployed to a number of platforms including HuggingFace, Railway, Replit & Vercel. Deployment guides for each platform can be found [here](https://github.com/AnswerDotAI/fh-deploy).\n",
     "\n",
     "::: {.callout-note}\n",
-    "We are actively working on supporting more hosting providers. PRs are welcome!\n",
+    "We are actively working on supporting more hosting providers. If you would like to add a guide for another platform feel free to submit a PR [here](https://github.com/AnswerDotAI/fh-deploy).\n",
     ":::"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Deploying to Railway\n",
-    "\n",
-    "To deploy to railway, you need to have a Railway account and the Railway CLI installed.\n",
-    "\n",
-    "1. Create a Railway account at [railway.app](https://railway.app/)\n",
-    "2. Install the Railway CLI for your [operating system](https://docs.railway.app/guides/cli#installing-the-cli).\n",
-    "3. Run `railway login` to log in to your Railway account.\n",
-    "\n",
-    "Next, navigate to the directory containing your FastHTML app and run the following command:\n",
-    "\n",
-    "```bash\n",
-    "fh_railway_deploy <app-name>\n",
-    "```\n",
-    "\n",
-    "::: {.callout-note}\n",
-    "Your app's entry point must be located in a `main.py` file for this to work.\n",
-    ":::\n",
-    "\n",
-    "`fh_railway_deploy` runs the following commands behind the scenes for you:\n",
-    "\n",
-    "```bash\n",
-    "railway init -n <app-name>\n",
-    "railway up -c\n",
-    "railway domain\n",
-    "railway link ...\n",
-    "railway volume add -m /app/data \n",
-    "```\n",
-    "It handles automatically linking your current app to a railway project, setting up all the environment variables such as the port to listen on and setting up a `requirements.txt` if you haven't one already."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Customizing your Domain Name\n",
-    "\n",
-    "Railway automatically assigns your website a unique domain name such as `quickdraw-production.up.railway.app`. However, if you want to use your own that you've purchased through services like [GoDaddy](https://www.godaddy.com/) or [Squarespace Domains](https://domains.squarespace.com/) and have users be able to navigate to your site using that domain, you'll need to configure it both in your domain registration service and in Railway. Railway has put together a nice tutorial for setting it up [here](https://docs.railway.app/guides/public-networking#custom-domains).\n",
-    "\n",
-    "::: {.callout-note}\n",
-    "Make sure to notice the difference between setting up a regular domain and a subdomain. Regular domains don't have any prefixes before the main site name such as `example.com` and is setup differently from a subdomain which might look like `subdomain.example.com`. Make sure to follow your domain registration service's documentation on how to set these types up.\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Unsupported platforms\n",
-    "\n",
-    "### Apache\n",
-    "\n",
-    "At this time the Apache HTTP Server doesn't support ASGI deployments, which includes FastHTML. We suggest instead running [uvicorn behind nginx](https://www.uvicorn.org/deployment/#running-behind-nginx).\n"
    ]
   }
  ],


### PR DESCRIPTION
This PR removes most deployment info from the docs which is added to fh-deloy in this [PR](https://github.com/AnswerDotAI/fh-deploy/pull/2).

Note: I didn't remove the deployment info in the e2e [tutorial](https://docs.fastht.ml/tutorials/e2e.html#deploying-to-railway) as it would have ruined the flow of the tutorial.