### PR TITLE
Add support for LaTeX formula rendering when rendering markdown

### DIFF
--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -7,8 +7,14 @@ def  dark_media(css): return Style('@media (prefers-color-scheme:  dark) {%s}' %
 def MarkdownJS(sel='.marked'):
     src = """
 import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
-import { proc_htmx} from "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js";
-proc_htmx('%s', e => e.innerHTML = marked.parse(e.textContent));
+import { proc_htmx } from "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js";
+import katex from "https://cdn.jsdelivr.net/npm/katex/dist/katex.mjs";
+
+const renderMath = tex => katex.renderToString(tex, {throwOnError: false, displayMode: false});
+
+proc_htmx('%s', e => {
+  e.innerHTML = marked.parse(e.textContent).replace(/\${1,2}\\n*(.+?)\\n*\${1,2}/g, (_, tex) => renderMath(tex));
+});
 """ % sel
     return Script(src, type='module')
 
@@ -38,4 +44,3 @@ import {proc_htmx} from "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fas
 proc_htmx('%s', Sortable.create);
 """ % sel
     return Script(src, type='module')
-

--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -4,18 +4,25 @@ from fasthtml.xtend import Script,jsd,Style
 def light_media(css): return Style('@media (prefers-color-scheme: light) {%s}' %css)
 def  dark_media(css): return Style('@media (prefers-color-scheme:  dark) {%s}' %css)
 
-def MarkdownJS(sel='.marked'):
-    src = """
-import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
-import { proc_htmx } from "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js";
-import katex from "https://cdn.jsdelivr.net/npm/katex/dist/katex.mjs";
+def MarkdownJS(sel='.marked', katex=False):
+    if katex:
+        src = """
+        import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
+        import { proc_htmx } from "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js";
+        import katex from "https://cdn.jsdelivr.net/npm/katex/dist/katex.mjs";
 
-const renderMath = tex => katex.renderToString(tex, {throwOnError: false, displayMode: false});
+        const renderMath = tex => katex.renderToString(tex, {throwOnError: false, displayMode: false});
 
-proc_htmx('%s', e => {
-  e.innerHTML = marked.parse(e.textContent).replace(/\${1,2}\\n*(.+?)\\n*\${1,2}/g, (_, tex) => renderMath(tex));
-});
-""" % sel
+        proc_htmx('%s', e => {
+        e.innerHTML = marked.parse(e.textContent).replace(/\${1,2}\\n*(.+?)\\n*\${1,2}/g, (_, tex) => renderMath(tex));
+        });
+        """ % sel
+    else:
+        src = """
+        import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
+        import { proc_htmx} from "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js";
+        proc_htmx('%s', e => e.innerHTML = marked.parse(e.textContent));
+        """ % sel
     return Script(src, type='module')
 
 

--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -6,13 +6,7 @@ def  dark_media(css): return Style('@media (prefers-color-scheme:  dark) {%s}' %
 
 def MarkdownJS(sel='.marked', katex=False, katex_tags='$'):
     if katex:
-        def add_escape_characters(input_string):
-            escaped_string = ""
-            for char in input_string:
-                escaped_string += "\\" + char
-            return escaped_string
-
-        katex_escaped_left_tags = add_escape_characters(katex_tags)
+        katex_escaped_left_tags = "\\" + katex_tags
         if katex_tags == '$':
             katex_escaped_right_tags = '\\$'
         if katex_tags == '[':

--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -4,8 +4,20 @@ from fasthtml.xtend import Script,jsd,Style
 def light_media(css): return Style('@media (prefers-color-scheme: light) {%s}' %css)
 def  dark_media(css): return Style('@media (prefers-color-scheme:  dark) {%s}' %css)
 
-def MarkdownJS(sel='.marked', katex=False):
+def MarkdownJS(sel='.marked', katex=False, katex_tags='$'):
     if katex:
+        def add_escape_characters(input_string):
+            escaped_string = ""
+            for char in input_string:
+                escaped_string += "\\" + char
+            return escaped_string
+
+        katex_escaped_left_tags = add_escape_characters(katex_tags)
+        if katex_tags == '$':
+            katex_escaped_right_tags = '\\$'
+        if katex_tags == '[':
+            katex_escaped_right_tags = '\\]'
+
         src = """
         import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
         import { proc_htmx } from "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js";
@@ -14,9 +26,9 @@ def MarkdownJS(sel='.marked', katex=False):
         const renderMath = tex => katex.renderToString(tex, {throwOnError: false, displayMode: false});
 
         proc_htmx('%s', e => {
-        e.innerHTML = marked.parse(e.textContent).replace(/\${1,2}\\n*(.+?)\\n*\${1,2}/g, (_, tex) => renderMath(tex));
+        e.innerHTML = marked.parse(e.textContent).replace(/%s{1,2}\\n*(.+?)\\n*%s{1,2}/g, (_, tex) => renderMath(tex));
         });
-        """ % sel
+        """ % (sel, katex_escaped_left_tags, katex_escaped_right_tags)
     else:
         src = """
         import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";


### PR DESCRIPTION
I added a few lines of code to support KaTeX formula rendering. Here is a test case:

```python
from fasthtml.common import *

hdrs = (
    MarkdownJS(), HighlightJS(langs=['python', 'javascript', 'html', 'css']),
    Link(rel='stylesheet', href='https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css')
)

app, rt = fast_app(hdrs=hdrs)

content = """
Here are some _markdown_ elements.

- This is a list item
- This is another list item
- And this is a third list item

```python
print("Hello, World!")
```

$$
1 \\times 2 = 2
$$

$$1 \\times 2 = 2$$

$1 \\times 2 = 2$

**Fenced code blocks work here.**
"""

@rt('/')
def get(req):
    return Titled("Markdown rendering example", Div(content,cls="marked"))

if __name__ == "__main__":
    import uvicorn
    uvicorn.run(
        "__main__:app",
        host="0.0.0.0",
        port=5001,
        reload=True,
    )
```