### PR TITLE
Make fill_form set selected option

### DIFF
--- a/fasthtml/components.py
+++ b/fasthtml/components.py
@@ -82,6 +82,10 @@ def _fill_item(item, obj):
                 else: attr.pop('checked', '')
             else: attr['value'] = val
         if tag=='textarea': cs=(val,)
+        if tag=='select':
+            for o in cs:
+                if o[0]=='option':
+                    if o[2].get('value', '')==val: o[2]['selected'] = '1'
     return FT(tag,cs,attr)
 
 # %% ../nbs/api/01_components.ipynb


### PR DESCRIPTION
Make fill_form set "selected" attribute on Options within Selects, so this is enough:
```python
Select(
    *[Option(x[0], value=x[1]) for x in RARITIES],
    id="rarity",
),
```
instead of
```python
Select(
    *[Option(x[0], value=x[1], selected=item.slot is x[1]) for x in RARITIES],
    id="rarity",
),
```