### PR TITLE
Add experimental formatting to html2ft

### DIFF
--- a/fasthtml/components.py
+++ b/fasthtml/components.py
@@ -120,7 +120,7 @@ def __getattr__(tag):
 
 # %% ../nbs/api/01_components.ipynb
 _re_h2x_attr_key = re.compile(r'^[A-Za-z_-][\w-]*$')
-def html2ft(html):
+def html2ft(html, style=None):
     """Convert HTML to an `ft` expression"""
     rev_map = {'class': 'cls', 'for': 'fr'}
     
@@ -142,7 +142,10 @@ def html2ft(html):
         j = ', ' if onlychild else f',\n{spc}'
         inner = j.join(filter(None, cs+attrs))
         if onlychild: return f'{tag_name}({inner})'
-        return f'{tag_name}(\n{spc}{inner}\n{" "*(lvl-1)*indent})'
+        if style is None or not attrs: return f'{tag_name}(\n{spc}{inner}\n{" "*(lvl-1)*indent})' 
+        inner_cs = j.join(filter(None, cs))
+        inner_attrs = ', '.join(filter(None, attrs))
+        return f'{tag_name}({inner_attrs})(\n{spc}{inner_cs}\n{" "*(lvl-1)*indent})'
 
     soup = BeautifulSoup(html.strip(), 'html.parser')
     for c in soup.find_all(string=risinstance(Comment)): c.extract()

--- a/nbs/api/01_components.ipynb
+++ b/nbs/api/01_components.ipynb
@@ -421,7 +421,7 @@
    "source": [
     "#| export\n",
     "_re_h2x_attr_key = re.compile(r'^[A-Za-z_-][\\w-]*$')\n",
-    "def html2ft(html):\n",
+    "def html2ft(html, style=None):\n",
     "    \"\"\"Convert HTML to an `ft` expression\"\"\"\n",
     "    rev_map = {'class': 'cls', 'for': 'fr'}\n",
     "    \n",
@@ -443,7 +443,10 @@
     "        j = ', ' if onlychild else f',\\n{spc}'\n",
     "        inner = j.join(filter(None, cs+attrs))\n",
     "        if onlychild: return f'{tag_name}({inner})'\n",
-    "        return f'{tag_name}(\\n{spc}{inner}\\n{\" \"*(lvl-1)*indent})'\n",
+    "        if style is None or not attrs: return f'{tag_name}(\\n{spc}{inner}\\n{\" \"*(lvl-1)*indent})' \n",
+    "        inner_cs = j.join(filter(None, cs))\n",
+    "        inner_attrs = ', '.join(filter(None, attrs))\n",
+    "        return f'{tag_name}({inner_attrs})(\\n{spc}{inner_cs}\\n{\" \"*(lvl-1)*indent})'\n",
     "\n",
     "    soup = BeautifulSoup(html.strip(), 'html.parser')\n",
     "    for c in soup.find_all(string=risinstance(Comment)): c.extract()\n",
@@ -486,6 +489,38 @@
    "source": [
     "h = to_xml(form)\n",
     "hl_md(html2ft(h), 'python')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c3db4e841d2dbb1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "```python\nBody(cls='myclass')(\n    Div(style='padding:3px')(\n        Div(\n            'Some text',\n            Input(name='me'),\n            Img(src='filename', data='1')\n        )\n    )\n)\n```",
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hl_md(html2ft('''\n",
+    "<body class=\"myclass\">\n",
+    "  <div style=\"padding:3px\">\n",
+    "    <div>\n",
+    "        Some text\n",
+    "        <input name=\"me\">\n",
+    "        <img src=\"filename\" data=\"1\">\n",
+    "    </div>\n",
+    "  </div>\n",
+    "</body>\n",
+    "''', 'experimental_formatting'), 'python')"
    ]
   },
   {


### PR DESCRIPTION
Adds the new experimental formatting to html2ft

```html
<body class="myclass">
  <div style="padding:3px">
    <div>
        Some text
        <input name="me">
        <img src="filename" data="1">
    </div>
  </div>
</body>
```

will turn into

```python
Body(cls='myclass')(
    Div(style='padding:3px')(
        Div(
            'Some text',
            Input(name='me'),
            Img(src='filename', data='1')
        )
    )
)
```