### PR TITLE
Fixed typo in tutorials index.

### DIFF
--- a/nbs/tutorials/index.qmd
+++ b/nbs/tutorials/index.qmd
@@ -8,5 +8,5 @@ listing:
   filter-ui: false
 ---
 
-Click through to any of these tutorials to get started with nbdev's features.
+Click through to any of these tutorials to get started with FastHTML's features.
 


### PR DESCRIPTION
I noticed a typo in the tutorials index page while reading through the docs and fixed it.