### PR TITLE
Use re.fullmatch for Beforeware

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -306,7 +306,7 @@ class RouteX(Route):
             if not resp:
                 if isinstance(b, Beforeware): bf,skip = b.f,b.skip
                 else: bf,skip = b,[]
-                if not any(re.match(r, req.url.path) for r in skip):
+                if not any(re.fullmatch(r, req.url.path) for r in skip):
                     resp = await _wrap_call(bf, req, _sig(bf).parameters)
         if not resp: resp = await _wrap_call(self.f, req, self.sig.parameters)
         for a in self.after:

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -980,7 +980,7 @@
     "            if not resp:\n",
     "                if isinstance(b, Beforeware): bf,skip = b.f,b.skip\n",
     "                else: bf,skip = b,[]\n",
-    "                if not any(re.match(r, req.url.path) for r in skip):\n",
+    "                if not any(re.fullmatch(r, req.url.path) for r in skip):\n",
     "                    resp = await _wrap_call(bf, req, _sig(bf).parameters)\n",
     "        if not resp: resp = await _wrap_call(self.f, req, self.sig.parameters)\n",
     "        for a in self.after:\n",


### PR DESCRIPTION
The docs, specifically [here](https://docs.fastht.ml/tutorials/quickstart_for_web_devs.html#authentication-and-authorization), suggest using

```python
beforeware = Beforeware(
    user_auth_before,
    skip=[r'/favicon\.ico', r'/static/.*', r'.*\.css', r'.*\.js', '/login', '/']
)

app, rt = fast_app(before=beforeware)
```

to set up user auth, but the '/' route in skip currently matches all routes. It seems the intention was to match the entire route, hence the change to re.fullmatch in this commit.