### PR TITLE
feat: (#225) Add support for application/json in POST requests

### DIFF
--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -176,7 +176,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2024, 8, 7, 14, 0)"
+       "datetime.datetime(2024, 8, 9, 14, 0)"
       ]
      },
      "execution_count": null,
@@ -623,11 +623,24 @@
    "source": [
     "#| export\n",
     "async def _from_body(req, p):\n",
-    "    form = await req.form()\n",
     "    anno = p.annotation\n",
     "    # Get the fields and types of type `anno`, if available\n",
     "    d = _annotations(anno)\n",
-    "    cargs = {k:_form_arg(k, v, d) for k,v in form2dict(form).items() if not d or k in d}\n",
+    "\n",
+    "    if req.headers.get('content-type') == 'application/json':\n",
+    "        data = await req.json()\n",
+    "        process_value = lambda k, v: v\n",
+    "    else:\n",
+    "        form = await req.form()\n",
+    "        data = form2dict(form)\n",
+    "        process_value = lambda k, v: _form_arg(k, v, d)\n",
+    "\n",
+    "    cargs = {\n",
+    "        k: process_value(k, v)\n",
+    "        for k, v in data.items()\n",
+    "        if not d or k in d\n",
+    "    }\n",
+    "    \n",
     "    return anno(**cargs)"
    ]
   },
@@ -1057,7 +1070,7 @@
     {
      "data": {
       "text/plain": [
-       "'a604e4a2-08e8-462d-aff9-15468891fe09'"
+       "'091b529e-f0be-4107-a22e-5644344a20d3'"
       ]
      },
      "execution_count": null,
@@ -1568,6 +1581,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9bf83ebc-4482-42ff-b2a5-4e4f4346626e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Testing POST with Content-Type: application/json\n",
+    "@dataclass\n",
+    "class Item:\n",
+    "    foo: str\n",
+    "    bar: int\n",
+    "\n",
+    "@app.post(\"/\")\n",
+    "def index(it: Item):\n",
+    "    return Titled(\"It worked!\", H2(f\"Foo: {it.foo}\"), H2(f\"Bar: {it.bar}\"))\n",
+    "\n",
+    "# Test for JSON POST request\n",
+    "def test_json_post():\n",
+    "    json_request_body = json.dumps({\"foo\": \"Lorem\", \"bar\": 15})\n",
+    "    response = cli.post('/', headers={\"Content-Type\": \"application/json\"}, data=json_request_body).text\n",
+    "    assert \"<title>It worked!</title>\" in response and \"<h2>Foo: Lorem</h2>\" in response and \"<h2>Bar: 15</h2>\" in response\n",
+    "\n",
+    "# Run the test\n",
+    "test_json_post()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "3366d88f",
    "metadata": {},
    "outputs": [],
@@ -1641,12 +1681,14 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": []
+     "text": [
+      "\n"
+     ]
     },
     {
      "data": {
       "text/plain": [
-       "'Cookie was set at time 11:23:43.161316'"
+       "'Cookie was set at time 11:31:16.627634'"
       ]
      },
      "execution_count": null,
@@ -1687,13 +1729,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Set to 2024-08-06 11:23:43.211716\n"
+      "Set to 2024-08-09 11:31:16.664303\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'Session time: 11:23:43.211716'"
+       "'Session time: 11:31:16.664303'"
       ]
      },
      "execution_count": null,
@@ -1927,14 +1969,6 @@
     "#|hide\n",
     "import nbdev; nbdev.nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5d9d25c7",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Addresses https://github.com/AnswerDotAI/fasthtml/issues/225

## 🗒️ Summary

- Modified `_from_body` function to handle JSON data
  - Implement conditional processing for JSON and form data
- Added test case for JSON POST request

## Demo

I used the Python virtual env and installed my custom branch as a package to sanity check the changes E2E. I was able to get the same error using the `curl` call and the same code mentioned in the GH Issue. After the changes, the `curl` call worked 🤠 

<details><summary>

### 🔥 Before (expand to see screenshot)

</summary>

![Screenshot from 2024-08-09 11-52-53](https://github.com/user-attachments/assets/1ca75add-2bc9-4a68-9b8c-acecf71ff135)

</details>

<details><summary>

### 🪄  After (expand to see screenshot)

</summary>

![Screenshot from 2024-08-09 11-49-22](https://github.com/user-attachments/assets/459a2d61-b2d2-4cbc-8062-b46689faf6f7)

</details>

## TDD
Initially, the test I added failed because the JSON parsing wasn't implemented yet. The screenshot below is a snippet of the error from the test before the changes were added.

```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[78], line 21
     18     assert "Bar: 15" in response
     20 # Run the test
---> 21 test_json_post()

Cell In[78], line 13, in test_json_post()
     12 def test_json_post():
---> 13     response = test_r(cli, '/', '{"foo": "Lorem", "bar": 15}', 'post',
     14                       headers={"Content-Type": "application/json"})
     16     assert "It worked!" in response
     17     assert "Foo: Lorem" in response

Cell In[70], line 3, in test_r(cli, path, exp, meth, hx, **kwargs)
      1 def test_r(cli, path, exp, meth='get', hx=False, **kwargs):
      2     if hx: kwargs['headers'] = {'hx-request':"1"}
----> 3     test_eq(getattr(cli, meth)(path, **kwargs).text, exp)

### inbetween stack trace stuff here ###

Cell In[34], line 8, in _from_body(req, p)
      6 d = _annotations(anno)
      7 cargs = {k:_form_arg(k, v, d) for k,v in form2dict(form).items() if not d or k in d}
----> 8 return anno(**cargs)

TypeError: Item.__init__() missing 2 required positional arguments: 'foo' and 'bar'

```
