### PR TITLE
Add Title component alongside Titled to avoid confusion

### DIFF
--- a/nbs/tutorials/quickstart_for_web_devs.ipynb
+++ b/nbs/tutorials/quickstart_for_web_devs.ipynb
@@ -148,7 +148,7 @@
     "\n",
     "@rt(\"/\")\n",
     "def get():\n",
-    "  return Titled(\"Chart Demo\", Div(id=\"myDiv\"),\n",
+    "  return Title(\"Chart Demo - FastHTML\"), Titled(\"Chart Demo\", Div(id=\"myDiv\"),\n",
     "    Script(f\"var data = {data}; Plotly.newPlot('myDiv', data);\"))\n",
     "\n",
     "serve()\n",


### PR DESCRIPTION
Quickstart guide containing tuple return helps cover variations. This also helps to avoid confusion b/w `Titled()` and `Title()`