### PR TITLE
Enhance LaTeX rendering in Markdown with support for environments

### DIFF
--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -28,9 +28,7 @@ def KatexMarkdownJS(sel='.marked', inline_delim='$', display_delim='$$', math_en
     };
     const processLatexEnvironments = (content) => {
         return content.replace(/\\begin{(\w+)}([\s\S]*?)\\end{\1}/g, (match, env, innerContent) => {
-            if ([%s].includes(env)) {
-                return `%s${match}%s`;
-            }
+            if ([%s].includes(env)) { return `%s${match}%s`; }
             return match;
         });
     };

--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -1,3 +1,4 @@
+import re
 from fastcore.utils import *
 from fasthtml.xtend import Script,jsd,Style,Link
 
@@ -12,16 +13,41 @@ def MarkdownJS(sel='.marked'):
     src = "proc_htmx('%s', e => e.innerHTML = marked.parse(e.textContent));" % sel
     return Script(marked_imp+src, type='module')
 
-def KatexMarkdownJS(sel='.marked', katex_tags='$'):
-    right_tags = '\\$' if katex_tags=='$' else '\\]'
+def KatexMarkdownJS(sel='.marked', inline_delim='$', display_delim='$$', math_envs=None):
+    math_envs = math_envs or ['equation', 'align', 'gather', 'multline']
+    env_list = ','.join(f"'{env}'" for env in math_envs)
+
     src = """
     import katex from "https://cdn.jsdelivr.net/npm/katex/dist/katex.mjs";
-    const renderMath = tex => katex.renderToString(tex, {throwOnError: false, displayMode: false});
-
+    const renderMath = (tex, displayMode) => {
+        return katex.renderToString(tex, {
+            throwOnError: false,
+            displayMode: displayMode,
+            output: 'html',
+            trust: true
+        });
+    };
+    const processLatexEnvironments = (content) => {
+        return content.replace(/\\\\begin{(\\w+)}([\\s\\S]*?)\\\\end{\\1}/g, (match, env, innerContent) => {
+            if ([%s].includes(env)) {
+                return `%s${match}%s`;
+            }
+            return match;
+        });
+    };
     proc_htmx('%s', e => {
-    e.innerHTML = marked.parse(e.textContent).replace(/%s{1,2}\\n*(.+?)\\n*%s{1,2}/g, (_, tex) => renderMath(tex));
+        let content = processLatexEnvironments(e.textContent);
+        // Handle display math (including environments)
+        content = content.replace(/%s([\\s\\S]+?)%s/gm, (_, tex) => renderMath(tex.trim(), true));
+        // Handle inline math
+        content = content.replace(/(?<!\\w)%s([^%s\\s](?:[^%s]*[^%s\\s])?)%s(?!\\w)/g, (_, tex) => renderMath(tex.trim(), false));
+        e.innerHTML = marked.parse(content);
     });
-    """ % (sel, "\\"+katex_tags, right_tags)
+    """ % (env_list, re.escape(display_delim), re.escape(display_delim),
+           sel, re.escape(display_delim), re.escape(display_delim),
+           re.escape(inline_delim), re.escape(inline_delim), re.escape(inline_delim),
+           re.escape(inline_delim), re.escape(inline_delim))
+
     return (Script(marked_imp+src, type='module'),
             Link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"))
 

--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -19,8 +19,7 @@ def KatexMarkdownJS(sel='.marked', inline_delim='$', display_delim='$$', math_en
 
     src = r"""
     import katex from "https://cdn.jsdelivr.net/npm/katex/dist/katex.mjs";
-    const renderMath = (tex, displayMode) => {
-        return katex.renderToString(tex, {
+    const renderMath = (tex, displayMode) => { return katex.renderToString(tex, {
             throwOnError: false,
             displayMode: displayMode,
             output: 'html',

--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -28,24 +28,27 @@ def KatexMarkdownJS(sel='.marked', inline_delim='$', display_delim='$$', math_en
     };
     const processLatexEnvironments = (content) => {
         return content.replace(/\\begin{(\w+)}([\s\S]*?)\\end{\1}/g, (match, env, innerContent) => {
-            if ([%s].includes(env)) { return `%s${match}%s`; }
+            if ([%(env_list)s].includes(env)) { return `%(display_delim)s${match}%(display_delim)s`; }
             return match;
         });
     };
-    proc_htmx('%s', e => {
+    proc_htmx('%(sel)s', e => {
         let content = processLatexEnvironments(e.textContent);
         // Handle display math (including environments)
-        content = content.replace(/%s([\s\S]+?)%s/gm, (_, tex) => renderMath(tex.trim(), true));
+        content = content.replace(/%(display_delim)s([\s\S]+?)%(display_delim)s/gm, (_, tex) => renderMath(tex.trim(), true));
         // Handle inline math
-        content = content.replace(/(?<!\w)%s([^%s\s](?:[^%s]*[^%s\s])?)%s(?!\w)/g, (_, tex) => renderMath(tex.trim(), false));
+        content = content.replace(/(?<!\w)%(inline_delim)s([^%(inline_delim)s\s](?:[^%(inline_delim)s]*[^%(inline_delim)s\s])?)%(inline_delim)s(?!\w)/g, (_, tex) => renderMath(tex.trim(), false));
         e.innerHTML = marked.parse(content);
     });
-    """ % (env_list, re.escape(display_delim), re.escape(display_delim),
-           sel, re.escape(display_delim), re.escape(display_delim),
-           re.escape(inline_delim), re.escape(inline_delim), re.escape(inline_delim),
-           re.escape(inline_delim), re.escape(inline_delim))
-
-    return (Script(marked_imp+src, type='module'),
+    """
+    format_dict = {
+        'env_list': env_list,
+        'sel': sel,
+        'display_delim': re.escape(display_delim),
+        'inline_delim': re.escape(inline_delim)
+    }
+    formatted_src = src % format_dict
+    return (Script(marked_imp + formatted_src, type='module'),
             Link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"))
 
 

--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -17,7 +17,7 @@ def KatexMarkdownJS(sel='.marked', inline_delim='$', display_delim='$$', math_en
     math_envs = math_envs or ['equation', 'align', 'gather', 'multline']
     env_list = ','.join(f"'{env}'" for env in math_envs)
 
-    src = """
+    src = r"""
     import katex from "https://cdn.jsdelivr.net/npm/katex/dist/katex.mjs";
     const renderMath = (tex, displayMode) => {
         return katex.renderToString(tex, {
@@ -28,7 +28,7 @@ def KatexMarkdownJS(sel='.marked', inline_delim='$', display_delim='$$', math_en
         });
     };
     const processLatexEnvironments = (content) => {
-        return content.replace(/\\\\begin{(\\w+)}([\\s\\S]*?)\\\\end{\\1}/g, (match, env, innerContent) => {
+        return content.replace(/\\begin{(\w+)}([\s\S]*?)\\end{\1}/g, (match, env, innerContent) => {
             if ([%s].includes(env)) {
                 return `%s${match}%s`;
             }
@@ -38,9 +38,9 @@ def KatexMarkdownJS(sel='.marked', inline_delim='$', display_delim='$$', math_en
     proc_htmx('%s', e => {
         let content = processLatexEnvironments(e.textContent);
         // Handle display math (including environments)
-        content = content.replace(/%s([\\s\\S]+?)%s/gm, (_, tex) => renderMath(tex.trim(), true));
+        content = content.replace(/%s([\s\S]+?)%s/gm, (_, tex) => renderMath(tex.trim(), true));
         // Handle inline math
-        content = content.replace(/(?<!\\w)%s([^%s\\s](?:[^%s]*[^%s\\s])?)%s(?!\\w)/g, (_, tex) => renderMath(tex.trim(), false));
+        content = content.replace(/(?<!\w)%s([^%s\s](?:[^%s]*[^%s\s])?)%s(?!\w)/g, (_, tex) => renderMath(tex.trim(), false));
         e.innerHTML = marked.parse(content);
     });
     """ % (env_list, re.escape(display_delim), re.escape(display_delim),


### PR DESCRIPTION
This PR improves the `KatexMarkdownJS` function to provide better LaTeX rendering capabilities within Markdown content. Key enhancements include:

1. Support for LaTeX environments (e.g., equation, align, gather, multline)
2. Separate handling for inline and display math
3. Customizable delimiters for inline and display math
4. Configurable list of LaTeX environments to be treated as display math

### Changes:

- Updated `KatexMarkdownJS` function in `fasthtml/js.py`
- Added support for processing LaTeX environments
- Improved regex patterns for more accurate inline and display math detection
- Made math delimiters and environment list customizable

### Breaking Change:
The `katex_tags` parameter has been replaced with separate `inline_delim` and `display_delim` parameters. Users who previously explicitly specified `katex_tags` will need to update their code.

#### Migration guide:
- Old: `KatexMarkdownJS(katex_tags='$')`
- New: `KatexMarkdownJS(inline_delim='$', display_delim='$$')`

### Minimum working example:
This example demonstrates some environments which failed before this PR and now render properly.
```python
from fasthtml.common import *

hdrs = (KatexMarkdownJS(),)
app, rt = fast_app(hdrs=hdrs)


@app.get("/")
def test():
    content = """
Here is some math $x+y=3$.

Examples of environments:
\\begin{align}
x &= y + z \\\\
a &= b + c + d + e
\\end{align}
and the equation environment:
\\begin{equation}
e = mc^2
\\end{equation}
Some more math using the display style deliminators:
$$
1 \\times 2 = 2
$$
final example
$$1 \\times 2 = 2$$
"""
    return Div(content, cls="marked")

serve()
```

Edit: attaching a before and after screenshot of the example app above.
![bef_aft](https://github.com/user-attachments/assets/08193b7f-a84c-4c8b-9f4e-5bcc88ecbc7e)
