### PR TITLE
Fixing typo in byo blog example.

### DIFF
--- a/nbs/tutorials/tutorial_for_web_devs.ipynb
+++ b/nbs/tutorials/tutorial_for_web_devs.ipynb
@@ -184,7 +184,7 @@
     "```\n",
     "\n",
     "1. The `string` and `random` libraries are part of Python's standard library\n",
-    "2. We these libraries to generate a random length list of random letters  called `letters` \n",
+    "2. We use these libraries to generate a random length list of random letters  called `letters` \n",
     "3. Using `letters` as the base we use list comprehension to generate a list of `Li` ft display components, each with their own letter and save that to the variable `items`\n",
     "4. Inside a call to the `Ul()` ft component we use Python's `*args` special syntax on the `items` variable. Therefore `*list` is treated not as one argument but rather a set of them.\n",
     "\n",


### PR DESCRIPTION
Found an typo in this page "https://docs.fastht.ml/tutorials/tutorial_for_web_devs.html"