### PR TITLE
chore(ci): add .codespellrc to simplify checking for typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,8 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = convertor,convertors,noo,socio-economic
+# If a file has many false positives, exclude here:
+skip = ./.git
+# To exclude base64 encoded strings, ignore all long base64 compatible strings
+ignore-regex = [A-Za-z0-9+/]{1000,}


### PR DESCRIPTION
Running `codespell` with this config results in no false positives and fixes the typos as in #279