### PR TITLE
Add missing import in adv example

### DIFF
--- a/examples/adv_app.py
+++ b/examples/adv_app.py
@@ -15,7 +15,7 @@ from fasthtml.common import (
     # These are the HTML components we use in this app
     A, AX, Button, Card, CheckboxX, Container, Div, Form, Grid, Group, H1, H2, Hidden, Input, Li, Main, Script, Style, Textarea, Title, Titled, Ul,
     # These are FastHTML symbols we'll use
-    Beforeware, fast_app, SortableJS, fill_form, picolink, serve,
+    Beforeware, FastHTML, fast_app, SortableJS, fill_form, picolink, serve,
     # These are from Starlette, Fastlite, fastcore, and the Python stdlib
     FileResponse, NotFoundError, RedirectResponse, database, patch, dataclass
 )


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Proposed Changes**
The `adv_app.py` example suggests an alternative to importing via `*`: importing the respective objects explicitly. Yet, one object is missing from this enumeration: `FastHTML`. This PR adds this missing object.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
