### PR TITLE
Set toasts to only work with FT responses

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -1,3 +1,4 @@
+from fastcore.xml import FT
 from fasthtml.core import *
 from fasthtml.components import *
 from fasthtml.xtend import *
@@ -50,9 +51,8 @@ def render_toasts(sess):
                hx_swap_oob="afterbegin:body")
 
 def toast_after(resp, req, sess):
-    if sk in sess: req.injects.append(render_toasts(sess))
+    if sk in sess and isinstance(resp, FT): req.injects.append(render_toasts(sess))
 
 def setup_toasts(app):
     app.router.hdrs += (Style(toast_css), Script(toast_js, type="module"))
     app.router.after.append(toast_after)
-

--- a/nbs/tutorials/quickstart_for_web_devs.ipynb
+++ b/nbs/tutorials/quickstart_for_web_devs.ipynb
@@ -907,7 +907,10 @@
     "- \"Data submitted\"\n",
     "- \"Request approved\"\n",
     "\n",
-    " Toasts take a little configuration plus views that use them require the `session` argument.\n",
+    " Toasts require the use of the `setup_toasts()` function plus every view needs these two features:\n",
+    "\n",
+    "- The session argument\n",
+    "- Must return FT components\n",
     "\n",
     "```python\n",
     "setup_toasts(app) # <1>\n",
@@ -923,9 +926,9 @@
     "    return Titled(\"I like toast\")\n",
     "```\n",
     "\n",
-    "1. `setup_toasts` is a helper function that adds toast dependencies. Usually this would be declared right after `fast_app()`.\n",
-    "2. Toasts require sessions.\n",
-    "\n"
+    "1. `setup_toasts` is a helper function that adds toast dependencies. Usually this would be declared right after `fast_app()`\n",
+    "2. Toasts require sessions\n",
+    "3. Views with Toasts must return FT components."
    ]
   },
   {

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -1,0 +1,33 @@
+from fasthtml.common import *
+from starlette.testclient import TestClient
+
+app, rt = fast_app()
+setup_toasts(app)
+cli = TestClient(app)
+
+@rt("/set-toast-get")
+def get(session):
+    add_toast(session, "Toast get", "info")
+    return RedirectResponse('/see-toast')
+
+@rt("/set-toast-post")
+def post(session):
+    add_toast(session, "Toast post", "info")
+    return RedirectResponse('/see-toast')
+
+@rt("/see-toast")
+def get(session):
+    return Titled("Hello, world!", P(str(session)))
+
+def test_get_toaster():
+    cli.get('/set-toast-get', follow_redirects=False)
+    res = cli.get('/see-toast')     
+    assert 'Toast get' in res.text
+
+    res = cli.get('/set-toast-get', follow_redirects=True)   
+    assert 'Toast get' in res.text    
+
+def test_post_toaster():
+    cli.post('/set-toast-post', follow_redirects=False)
+    res = cli.get('/see-toast')     
+    assert 'Toast post' in res.text


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] Set toasts to only work with FT responses'
labels: 'BUG'
assignees: 'pydanny'
---

**Related Issue**

- #358 

**Proposed Changes**

1. Checks that toasts only work with responses that are FT components
2. Documents in the quickstart that toasts only work with FT component responses.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

