### PR TITLE
Removed unused args in toaster.py

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -50,7 +50,7 @@ def render_toasts(sess):
     return Div(Div(*toasts, cls="fh-toast-container"),
                hx_swap_oob="afterbegin:body")
 
-def toast_after(resp, req, sess):
+def toast_after(req, sess):
     if sk in sess and isinstance(resp, FT): req.injects.append(render_toasts(sess))
 
 def setup_toasts(app):


### PR DESCRIPTION
Removed unused args in toaster.py because it logs this error in the console.
```
.venv/lib/python3.12/site-packages/fasthtml/core.py:157: UserWarning: `resp has no type annotation and is not a recognised special name, so is ignored.
  warn(f"`{arg} has no type annotation and is not a recognised special name, so is ignored.")
  ```

---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
Please link to the issue that this pull request addresses. If there isn't one, please create an issue first.

**Proposed Changes**
Describe the big picture of your changes here. If it fixes a bug or resolves a feature request, be sure to link to that issue.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
