### PR TITLE
Make improvements to `FastHTML By Example`

### DIFF
--- a/nbs/tutorials/by_example.ipynb
+++ b/nbs/tutorials/by_example.ipynb
@@ -15,9 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "There are lots of non-FastHTML-specific tricks and patterns involved in building web apps. The main goal of this tutorial is to give an alternate introduction to FastHTML. Building out example applications to show common patterns used. Also, illustrate some of the ways you can build on top of the FastHTML foundations to create your own custom web apps. A secondary goal is to have this be a useful document to add to the context of an LLM to turn it into a useful FastHTML assistant.\n",
+    "This tutorial provides an alternate introduction to FastHTML by building out example applications. We also illustrate how to use FastHTML foundations to create custom web apps. Finally, this document serves as minimal context for a LLM to turn it into a FastHTML assistant.\n",
     "\n",
     "Let's get started."
    ]
@@ -46,20 +44,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fasthtml.common import FastHTML\n",
+    "from fasthtml.common import FastHTML, serve\n",
     "\n",
     "app = FastHTML()\n",
     "\n",
     "@app.get(\"/\")\n",
     "def home():\n",
-    "    return \"<h1>Hello, World</h1>\""
+    "    return \"<h1>Hello, World</h1>\"\n",
+    "\n",
+    "serve()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To run this app, place it in a file, say `app.py`, and then run it with `uvicorn app:app --reload`. (We recommend that Windows users run the Uvicorn server via WSL to avoid [this issue](https://github.com/encode/uvicorn/issues/1972).) You'll see a message like this:\n",
+    "To run this app, place it in a file, say `app.py`, and then run it with `python app.py`.\n",
+    "\n",
     "```\n",
     "INFO:     Will watch for changes in these directories: ['/home/jonathan/fasthtml-example']\n",
     "INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)\n",
@@ -69,7 +70,12 @@
     "INFO:     Application startup complete.\n",
     "```\n",
     "\n",
-    "If you navigate to http://127.0.0.1:8000 in a browser, you'll see your \"Hello, World\". If you edit the `app.py` file and save it, the server will reload and you'll see the updated message when you refresh the page in your browser."
+    "If you navigate to [http://127.0.0.1:8000](http://127.0.0.1:8000) in a browser, you'll see your \"Hello, World\". If you edit the `app.py` file and save it, the server will reload and you'll see the updated message when you refresh the page in your browser.  \n",
+    "\n",
+    ":::{.callout-tip}\n",
+    "# Live Reloading\n",
+    "You can also enable [live reloading](../ref/live_reload.ipynb) so you don't have to manually refresh your browser while editing it.\n",
+    ":::"
    ]
   },
   {
@@ -172,11 +178,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from fasthtml.common import *\n",
     "app = FastHTML()\n",
     "\n",
     "@app.get(\"/\")\n",
     "def home():\n",
-    "    return Div(H1('Hello, World'), P('Some text'), P('Some more text'))"
+    "    page = Html(\n",
+    "        Head(Title('Some page')),\n",
+    "        Body(Div('Some text, ', A('A link', href='https://example.com'), Img(src=\"https://placehold.co/200\"), cls='myclass')))\n",
+    "    return page\n",
+    "\n",
+    "serve()"
    ]
   },
   {
@@ -201,21 +213,28 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'<!doctype html></!doctype>\\n\\n<html>\\n  <head>\\n    <title>FastHTML page</title>\\n    <meta charset=\"utf-8\"></meta>\\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\"></meta>\\n    <script src=\"https://unpkg.com/htmx.org@next/dist/htmx.min.js\"></script>\\n    <script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@1.3.0/surreal.js\"></script>\\n    <script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script>\\n  </head>\\n  <body>\\n<div>\\n  <h1>Hello, World</h1>\\n  <p>Some text</p>\\n  <p>Some more text</p>\\n</div>\\n  </body>\\n</html>\\n'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<html>\n",
+      "  <head><title>Some page</title>\n",
+      "</head>\n",
+      "  <body><div class=\"myclass\">\n",
+      "Some text, \n",
+      "  <a href=\"https://example.com\">A link</a>\n",
+      "  <img src=\"https://placehold.co/200\">\n",
+      "</div>\n",
+      "</body>\n",
+      "</html>\n",
+      "\n"
+     ]
     }
    ],
    "source": [
     "from starlette.testclient import TestClient\n",
     "client = TestClient(app)\n",
     "r = client.get(\"/\")\n",
-    "r.text"
+    "print(r.text)"
    ]
   },
   {
@@ -223,7 +242,7 @@
    "metadata": {},
    "source": [
     "FastHTML wraps things in an Html tag if you don't do it yourself (unless the request comes from htmx, in which case you get the element directly). \n",
-    "See the section 'FT objects and HTML' for more on creating custom components or adding HTML rendering to existing python objects.\n",
+    "See [FT objects and HTML](#ft-objects-and-html) for more on creating custom components or adding HTML rendering to existing Python objects.\n",
     "To give the page a non-default title, return a Title before your main content:"
    ]
   },
@@ -303,7 +322,11 @@
     "\n",
     "This says that when someone navigates to the root URL \"/\" (i.e. sends a GET request), they will see the big \"Hello, World\" heading. When someone submits a POST or PUT request to the same URL, the server should return the string \"got a post or put request\".\n",
     "\n",
-    "Aside: You can test the POST request with `curl -X POST http://127.0.0.1:8000 -d \"some data\"`. This sends some data to the server, you should see the response \"got a post or put request\" printed in the terminal.\n",
+    ":::{.callout-tip}\n",
+    "## Test the POST request\n",
+    "\n",
+    "You can test the POST request with `curl -X POST http://127.0.0.1:8000 -d \"some data\"`. This sends some data to the server, you should see the response \"got a post or put request\" printed in the terminal.\n",
+    ":::\n",
     "\n",
     "There are a few other ways you can specify the route+method - FastHTML has `.get`, `.post`, etc. as shorthand for `route(..., methods=['get'])`, etc."
    ]
@@ -323,7 +346,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " Or you can use the `@app.route` decorator without a method but specify the method with the name of the function. For example:"
+    " Or you can use the `@rt` decorator without a method but specify the method with the name of the function. For example:"
    ]
   },
   {
@@ -332,7 +355,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@app.route(\"/\")\n",
+    "rt = app.route\n",
+    "\n",
+    "@rt(\"/\")\n",
     "def post():\n",
     "    return \"Hello World from a POST request\""
    ]
@@ -361,7 +386,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You're welcome to pick whichever style you prefer. Using routes lets you show different content on different pages - '/home', '/about' and so on. You can also respond differently to different kinds of requests to the same route, as shown above. You can also pass data via the route:"
+    "You're welcome to pick whichever style you prefer. Using routes lets you show different content on different pages - '/home', '/about' and so on. You can also respond differently to different kinds of requests to the same route, as shown above. You can also pass data via the route:\n",
+    "\n",
+    ":::{.panel-tabset}\n",
+    "\n",
+    "## `@app.get`"
    ]
   },
   {
@@ -392,7 +421,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "More on this in the 'More on Routing and Request Parameters' section, which goes deeper into the different ways to get information from a request."
+    "## `@rt`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Good day to you, Dave!'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@rt(\"/greet/{nm}\")\n",
+    "def get(nm:str):\n",
+    "    return f\"Good day to you, {nm}!\"\n",
+    "\n",
+    "client.get(\"/greet/Dave\").text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "More on this in the [More on Routing and Request Parameters](#more-on-routing-and-request-parameters) section, which goes deeper into the different ways to get information from a request."
    ]
   },
   {
@@ -406,7 +473,62 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plain HTML probably isn't quite what you imagine when you visualize your beautiful web app. CSS is the go-to language for styling HTML. But again, we don't want to learn extra languages unless we absolutely have to! Fortunately, there are ways to get much more visually appealing sites by relying on the hard work of others, using existing CSS libraries. One of our favourites is [PicoCSS](https://picocss.com/). To add a CSS file to HTML, you can use the `<link>` tag. Since we typically want things like CSS styling on all pages of our app, FastHTML lets you add shared headers when you define your app. And it already has `picolink` defined for convenience. As per the [pico docs](https://picocss.com/docs), we put all of our content inside a `<main>` tag with a class of `container`: "
+    "Plain HTML probably isn't quite what you imagine when you visualize your beautiful web app. CSS is the go-to language for styling HTML. But again, we don't want to learn extra languages unless we absolutely have to! Fortunately, there are ways to get much more visually appealing sites by relying on the hard work of others, using existing CSS libraries. One of our favourites is [PicoCSS](https://picocss.com/). A common way to add CSS files to web pages is to use a [`<link>`](https://www.w3schools.com/tags/tag_link.asp) tag inside your [HTML header](https://www.w3schools.com/tags/tag_header.asp), like this:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```html\n",
+    "<header>\n",
+    "    ...\n",
+    "    <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css\">\n",
+    "</header>\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For convenience, FastHTML already defines a Pico component for you with `picolink`: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css\">\n",
+      "\n",
+      "<style>:root { --pico-font-size: 100%; }</style>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(to_xml(picolink))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note}\n",
+    "`picolink` also includes a `<style>` tag, as we found that setting the font-size to 100% to be a good default.  We show you how to override this below.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we typically want CSS styling on all pages of our app, FastHTML lets you define a shared HTML header with the `hdrs` argument as shown below:"
    ]
   },
   {
@@ -416,20 +538,35 @@
    "outputs": [],
    "source": [
     "from fasthtml.common import *\n",
-    "# App with custom styling to override the pico defaults\n",
-    "css = Style(':root { --pico-font-size: 100%; --pico-font-family: Pacifico, cursive;}')\n",
-    "app = FastHTML(hdrs=(picolink, css))\n",
+    "css = Style(':root {--pico-font-size:90%,--pico-font-family: Pacifico, cursive;}') # <1>\n",
+    "app = FastHTML(hdrs=(picolink, css)) # <2>\n",
     "\n",
     "@app.route(\"/\")\n",
     "def get():\n",
-    "    return Title(\"Hello World\"), Main(H1('Hello, World'), cls=\"container\")"
+    "    return (Title(\"Hello World\"), \n",
+    "            Main(H1('Hello, World'), cls=\"container\")) # <3>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Aside: We're returning a tuple here (a title and the main page). This is needed to tell FastHTML to turn the main body into a full HTML page that includes the headers (including the pico link and our custom css) which we passed in."
+    "1. Custom styling to override the pico defaults\n",
+    "2. Define shared headers for all pages\n",
+    "3. As per the [pico docs](https://picocss.com/docs), we put all of our content inside a `<main>` tag with a class of `container`:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note}\n",
+    "\n",
+    "## Returning Tuples\n",
+    "\n",
+    "We're returning a tuple here (a title and the main page). This is needed to tell FastHTML to turn the main body into a full HTML page that includes the headers (including the pico link and our custom css) which we passed in.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -1846,5 +1983,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Small PR as I'm working my way carefully through this document.  I suspect I will make multiple PRs onto this document. 

Changes made:

1. Use `serve()` instead of Uvicorn
2. Include links in places where there should be links
2. Make some of the language more succint (less is more)
3. Remove the bit about this doc serving as context because there is now `llm-ctx.txt` and friends
4. Update for new `@rt` decorator, and add a tabset panel so people can see the difference
5. Clarify some of the language assuming people are new to web development.
6. Move all `Asides` into Quarto callouts

Im only 25% of the way through just though I would open an early PR.  Don't want to make a big PR if these changes are not aligned with what you want to do!

>[!Important]
> I have generated [a preview link for the page I changed](https://66d0c49fad8823743fde7a8e--fasthtml-preview.netlify.app/tutorials/by_example) to make reviewing easier on Netlify

cc: @johnowhitaker @jph00 