### PR TITLE
[Fix] Make sure only the selected radio button in a radio group is checked during form_fill

### DIFF
--- a/fasthtml/components.py
+++ b/fasthtml/components.py
@@ -97,8 +97,11 @@ def _fill_item(item, obj):
     val = None if name is None else obj.get(name, None)
     if val is not None and not 'skip' in attr:
         if tag=='input':
-            if attr.get('type', '') in ('checkbox','radio'):
+            if attr.get('type', '') == 'checkbox':
                 if val: attr['checked'] = '1'
+                else: attr.pop('checked', '')
+            elif attr.get('type', '') == 'radio':
+                if val and val == attr['value']: attr['checked'] = '1'
                 else: attr.pop('checked', '')
             else: attr['value'] = val
         if tag=='textarea': cs=(val,)

--- a/nbs/api/01_components.ipynb
+++ b/nbs/api/01_components.ipynb
@@ -403,8 +403,11 @@
     "    val = None if name is None else obj.get(name, None)\n",
     "    if val is not None and not 'skip' in attr:\n",
     "        if tag=='input':\n",
-    "            if attr.get('type', '') in ('checkbox','radio'):\n",
+    "            if attr.get('type', '') == 'checkbox':\n",
     "                if val: attr['checked'] = '1'\n",
+    "                else: attr.pop('checked', '')\n",
+    "            elif attr.get('type', '') == 'radio':\n",
+    "                if val and val == attr['value']: attr['checked'] = '1'\n",
     "                else: attr.pop('checked', '')\n",
     "            else: attr['value'] = val\n",
     "        if tag=='textarea': cs=(val,)\n",
@@ -795,9 +798,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "conda-base-py",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
---
name: Radio Group fill_form fix
about: Make sure only the selected radio button in a radio group is checked during form_fill
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
https://github.com/AnswerDotAI/fasthtml/issues/423

**Proposed Changes**
This handles radio type inputs separately to check if the value key of the radio input is equal to the `val` of the `obj` that is filling in the radio group

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
See the issue: https://github.com/AnswerDotAI/fasthtml/issues/423

this is the working mre where refreshing the page keeps the radio selection on True
![working_mre](https://github.com/user-attachments/assets/e3669ae1-844f-4cb3-8b4b-9dbd9756aca9)

