### PR TITLE
Fix proc_htmx bug

### DIFF
--- a/fasthtml/js.py
+++ b/fasthtml/js.py
@@ -27,7 +27,7 @@ def dark_media(
 
 # %% ../nbs/api/03_js.ipynb
 marked_imp = """import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
-    import { proc_htmx } from "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js";
+    import "https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js";
 """
 npmcdn = 'https://cdn.jsdelivr.net/npm/'
 

--- a/nbs/api/03_js.ipynb
+++ b/nbs/api/03_js.ipynb
@@ -129,7 +129,7 @@
    "source": [
     "#| export\n",
     "marked_imp = \"\"\"import { marked } from \"https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js\";\n",
-    "    import { proc_htmx } from \"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js\";\n",
+    "    import \"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js\";\n",
     "\"\"\"\n",
     "npmcdn = 'https://cdn.jsdelivr.net/npm/'"
    ]


### PR DESCRIPTION
---
name: Fix proc_htmx bug
about: Corrects the error: `Uncaught SyntaxError: The requested module 'https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js/fasthtml.js' does not provide an export named 'proc_htmx'`
title: '[PR] Fix proc_htmx bug'
labels: 'bug'
assignees: '@jph00'

---

**Related Issue**

#432 

**Proposed Changes**

Corrects the JS import to not point at just the `proc_htmx` function, which is already loaded.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

