### PR TITLE
Update PageX function

### DIFF
--- a/fasthtml/fastapp.py
+++ b/fasthtml/fastapp.py
@@ -94,4 +94,7 @@ def fast_app(
 
 # %% ../nbs/api/10_fastapp.ipynb
 def ContainerX(*cs, **kwargs): return Main(*cs, **kwargs, cls='container', hx_push_url='true', hx_swap_oob='true', id='main')
-def PageX(title, h1=None, *con): return Title(title), ContainerX(H1(h1 if h1 else title), *con)
+def PageX(title, *con, **kwargs):
+    h1_title = kwargs['h1'] if 'h1' in kwargs else title
+    return Title(title), ContainerX(H1(h1_title), *con)
+

--- a/fasthtml/fastapp.py
+++ b/fasthtml/fastapp.py
@@ -94,4 +94,4 @@ def fast_app(
 
 # %% ../nbs/api/10_fastapp.ipynb
 def ContainerX(*cs, **kwargs): return Main(*cs, **kwargs, cls='container', hx_push_url='true', hx_swap_oob='true', id='main')
-def PageX(title, *con): return Title(title), ContainerX(H1(title), *con)
+def PageX(title, h1=None, *con): return Title(title), ContainerX(H1(h1 if h1 else title), *con)

--- a/nbs/api/10_fastapp.ipynb
+++ b/nbs/api/10_fastapp.ipynb
@@ -158,7 +158,7 @@
    "source": [
     "#| export\n",
     "def ContainerX(*cs, **kwargs): return Main(*cs, **kwargs, cls='container', hx_push_url='true', hx_swap_oob='true', id='main')\n",
-    "def PageX(title, *con): return Title(title), ContainerX(H1(title), *con)"
+    "def PageX(title, h1=None, *con): return Title(title), ContainerX(H1(h1 if h1 else title), *con)"
    ]
   },
   {
@@ -177,5 +177,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/nbs/api/10_fastapp.ipynb
+++ b/nbs/api/10_fastapp.ipynb
@@ -151,6 +151,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default the same text is used for the browser title, and the main `H1` tag. You can optionally override the `H1` text via the `h1` parameter:\n",
+    "\n",
+    "```\n",
+    "PageX('Title', Ul(Li('One'), Li('Two'), Li('Three')), P('Just a paragraph'), h1='H1 Heading')\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -158,7 +169,9 @@
    "source": [
     "#| export\n",
     "def ContainerX(*cs, **kwargs): return Main(*cs, **kwargs, cls='container', hx_push_url='true', hx_swap_oob='true', id='main')\n",
-    "def PageX(title, h1=None, *con): return Title(title), ContainerX(H1(h1 if h1 else title), *con)"
+    "def PageX(title, *con, **kwargs):\n",
+    "    h1_title = kwargs['h1'] if 'h1' in kwargs else title\n",
+    "    return Title(title), ContainerX(H1(h1_title), *con)\n"
    ]
   },
   {


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Proposed Changes**
This PR updates the `PageX` function to optionally accept a named `h1` argument that will override the main `H1` tag, so that it can be different to the browser title text.

With the updated component you can now do something like this to have different text for the `H1` tag:

```
PageX('Title', Ul(Li('One'), Li('Two'), Li('Three')), P('Just a paragraph'), h1='H1 Heading')
```

This will add 'Title' as the browser tab title, and 'H1 Heading' as the main page `H1` tag text.

Note: This does not break any current uses of `PageX` as the new named parameter is entirely optional. So this will still work as expected:

```
PageX('Title', Ul(Li('One'), Li('Two'), Li('Three')), P('Just a paragraph'))
```

This will add 'Title' as the browser tab title, **and** as the main page `H1` tag.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
My motivation for this came about when I was looking at doing a PR for the [fasthtml-tut](https://github.com/AnswerDotAI/fasthtml-tut) repo to update the examples there. I thought it would be nice to be able to use `PageX()` to add the Python file as the browser title, and the relevant text (e.g. 'Todo list') as the `H1` text.

At the moment you can't do this as the first positional argument for `PageX` is used for the browser title **and** `H1` tag.