### PR TITLE
Allow custom messages to be outputted when the terminal starts

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -588,7 +588,8 @@ def serve(
         port=None, # If port is None it will default to 5001 or the PORT environment variable
         reload=True, # Default is to reload the app upon code changes
         reload_includes:list[str]|str|None=None, # Additional files to watch for changes
-        reload_excludes:list[str]|str|None=None # Files to ignore for changes
+        reload_excludes:list[str]|str|None=None, # Files to ignore for changes
+        msg:list[str]|None=None, # List of terminal messages to print
         ): 
     "Run the app in an async server, with live reload set as the default."
     bk = inspect.currentframe().f_back
@@ -599,7 +600,9 @@ def serve(
         elif code.co_name=='main' and bk.f_back.f_globals.get('__name__')=='__main__': appname = inspect.getmodule(bk).__name__
     if appname:
         if not port: port=int(os.getenv("PORT", default=5001))
-        print(f'Link: http://{"localhost" if host=="0.0.0.0" else host}:{port}')
+        if isinstance(msg, str):msg = (msg,)
+        msgs = (f'Link: http://{"localhost" if host=="0.0.0.0" else host}:{port}', *msg)
+        for m in msgs: print(m)
         uvicorn.run(f'{appname}:{app}', host=host, port=port, reload=reload, reload_includes=reload_includes, reload_excludes=reload_excludes)
 
 # %% ../nbs/api/00_core.ipynb

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1467,7 +1467,8 @@
     "        port=None, # If port is None it will default to 5001 or the PORT environment variable\n",
     "        reload=True, # Default is to reload the app upon code changes\n",
     "        reload_includes:list[str]|str|None=None, # Additional files to watch for changes\n",
-    "        reload_excludes:list[str]|str|None=None # Files to ignore for changes\n",
+    "        reload_excludes:list[str]|str|None=None, # Files to ignore for changes\n",
+    "        msg:list[str]|None=None, # List of terminal messages to print\n",
     "        ): \n",
     "    \"Run the app in an async server, with live reload set as the default.\"\n",
     "    bk = inspect.currentframe().f_back\n",
@@ -1478,7 +1479,9 @@
     "        elif code.co_name=='main' and bk.f_back.f_globals.get('__name__')=='__main__': appname = inspect.getmodule(bk).__name__\n",
     "    if appname:\n",
     "        if not port: port=int(os.getenv(\"PORT\", default=5001))\n",
-    "        print(f'Link: http://{\"localhost\" if host==\"0.0.0.0\" else host}:{port}')\n",
+    "        if isinstance(msg, str):msg = (msg,)\n",
+    "        msgs = (f'Link: http://{\"localhost\" if host==\"0.0.0.0\" else host}:{port}', *msg)\n",
+    "        for m in msgs: print(m)\n",
     "        uvicorn.run(f'{appname}:{app}', host=host, port=port, reload=reload, reload_includes=reload_includes, reload_excludes=reload_excludes)"
    ]
   },


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Proposed Changes**
This PR allows users to specify additional terminal messages, outputted when the server starts. By default a terminal message linking to the localhost web app is outputted:

```
Link: http://localhost:5001
```

I thought that it would be useful to be able to optionally specify custom messages too. For example, when your app includes a db then it is useful in development to be able to view/edit the db in the browser. If I wrap the `serve()` function and run the db viewer in a subprocess a minimal app would look something like this:

```
from fasthtml.common import * 
import subprocess

app,rt,todos,Todo = fast_app('data/todos.db', id=int, title=str, done=bool, pk='id')

@rt("/")
def get():
	return Div('Welcome to FastHTML!')

def serve_db(db_path='data/data.db', port=8083):
    sqlite_process = subprocess.Popen(
        ['sqlite_web', db_path, '--port', str(port), '--no-browser'],
        stdout=subprocess.DEVNULL,
        stderr=subprocess.DEVNULL
    )

    try:
        serve(msg=(f'SQLite: http://localhost:{port}'))
    finally:
        sqlite_process.terminate()

serve_db()
```

Notice the call to `serve()` passes in a `msg` argument:

`serve(msg=(f'SQLite: http://localhost:{port}'))`

This PR updates the `serve()` function to accept a string, or tuple of string messages to be outputted after the default meassage `Link: http://localhost:5001`, and produces output like this:

![image](https://github.com/user-attachments/assets/568514f2-2075-4000-8be7-fcd0052be2dc)

Notice that below the default message, there is now an additional message that outputs a link that opens up the db viewer/editor in the browser.

![image](https://github.com/user-attachments/assets/c3b035a8-0808-4f94-8258-1b7f2eeeecbf)

**So, now we have a way to conveniently add to the default terminal message for inserting links to other running services, or anything else you like!**

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.