### PR TITLE
Added missing IPython dependency

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -4,7 +4,7 @@ lib_name = fasthtml
 version = 0.6.7
 min_python = 3.10
 license = apache2
-requirements = fastcore>=1.7.8 python-dateutil starlette>0.33 oauthlib itsdangerous uvicorn[standard]>=0.30 httpx fastlite>=0.0.9 python-multipart beautifulsoup4
+requirements = fastcore>=1.7.8 python-dateutil starlette>0.33 oauthlib itsdangerous uvicorn[standard]>=0.30 httpx fastlite>=0.0.9 python-multipart beautifulsoup4 IPython
 dev_requirements = ipython lxml pysymbol_llm
 black_formatting = False
 conda_user = fastai


### PR DESCRIPTION
After the update in 0.6.5 that adds jupyter support IPython is required, but as it was missing from the dependencies is not installed by pip/conda


**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

