### PR TITLE
Support explicit iframe height in Jupyter HTMX

### DIFF
--- a/fasthtml/jupyter.py
+++ b/fasthtml/jupyter.py
@@ -90,7 +90,7 @@ def FastJupy(hdrs=None, middleware=None, **kwargs):
 # %% ../nbs/api/06_jupyter.ipynb
 def HTMX(host='localhost', port=8000, iframe_height="auto"):
     "An iframe which displays the HTMX application in a notebook."
-    return HTML(f'<iframe src="http://{host}:{port}" style="width: 100%; height: {iframe_height} border: none;" ' + """onload="{
+    return HTML(f'<iframe src="http://{host}:{port}" style="width: 100%; height: {iframe_height}; border: none;" ' + """onload="{
         let frame = this;
         window.addEventListener('message', function(e) {
             if (e.data.height) frame.style.height = (e.data.height+1) + 'px';

--- a/fasthtml/jupyter.py
+++ b/fasthtml/jupyter.py
@@ -88,9 +88,9 @@ def FastJupy(hdrs=None, middleware=None, **kwargs):
     return FastHTML(hdrs=hdrs, middleware=middleware, **kwargs)
 
 # %% ../nbs/api/06_jupyter.ipynb
-def HTMX(host='localhost', port=8000):
+def HTMX(host='localhost', port=8000, iframe_height="auto"):
     "An iframe which displays the HTMX application in a notebook."
-    return HTML(f'<iframe src="http://{host}:{port}" ' + """style="width: 100%; border: none;" onload="{
+    return HTML(f'<iframe src="http://{host}:{port}" style="width: 100%; height: {iframe_height} border: none;" ' + """onload="{
         let frame = this;
         window.addEventListener('message', function(e) {
             if (e.data.height) frame.style.height = (e.data.height+1) + 'px';

--- a/nbs/api/06_jupyter.ipynb
+++ b/nbs/api/06_jupyter.ipynb
@@ -292,9 +292,9 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def HTMX(host='localhost', port=8000):\n",
+    "def HTMX(host='localhost', port=8000, iframe_height=\"auto\"):\n",
     "    \"An iframe which displays the HTMX application in a notebook.\"\n",
-    "    return HTML(f'<iframe src=\"http://{host}:{port}\" ' + \"\"\"style=\"width: 100%; border: none;\" onload=\"{\n",
+    "    return HTML(f'<iframe src=\"http://{host}:{port}\" style=\"width: 100%; height: {iframe_height} border: none;\" ' + \"\"\"onload=\"{\n",
     "        let frame = this;\n",
     "        window.addEventListener('message', function(e) {\n",
     "            if (e.data.height) frame.style.height = (e.data.height+1) + 'px';\n",
@@ -328,7 +328,10 @@
    "outputs": [],
    "source": [
     "# Run the notebook locally to see the HTMX iframe in action\n",
-    "# HTMX()"
+    "# HTMX()\n",
+    "\n",
+    "# If only part of the page gets displayed, try tweaking the iframe_height parameter, for example:\n",
+    "# HTMX(iframe_height=\"800px\")"
    ]
   },
   {

--- a/nbs/api/06_jupyter.ipynb
+++ b/nbs/api/06_jupyter.ipynb
@@ -294,7 +294,7 @@
     "#| export\n",
     "def HTMX(host='localhost', port=8000, iframe_height=\"auto\"):\n",
     "    \"An iframe which displays the HTMX application in a notebook.\"\n",
-    "    return HTML(f'<iframe src=\"http://{host}:{port}\" style=\"width: 100%; height: {iframe_height} border: none;\" ' + \"\"\"onload=\"{\n",
+    "    return HTML(f'<iframe src=\"http://{host}:{port}\" style=\"width: 100%; height: {iframe_height}; border: none;\" ' + \"\"\"onload=\"{\n",
     "        let frame = this;\n",
     "        window.addEventListener('message', function(e) {\n",
     "            if (e.data.height) frame.style.height = (e.data.height+1) + 'px';\n",


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
Please link to the issue that this pull request addresses. If there isn't one, please create an issue first.

**Proposed Changes**
Allow specifying iframe height explicitly when using HTMX in jupyter. As per discussion on discord, some jupyter notebook clients do not display the whole content of the page. Supporting explicit height setting helps address this. Tested with VScode Jupyter 

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.
