### PR TITLE
Added an optional argument for the Titled() component

### DIFF
--- a/fasthtml/xtend.py
+++ b/fasthtml/xtend.py
@@ -179,9 +179,10 @@ def jsd(org, repo, root, path, prov='gh', typ='script', ver=None, esm=False, **k
 
 # %% ../nbs/api/02_xtend.ipynb
 @delegates(ft_hx, keep=True)
-def Titled(title:str="FastHTML app", *args, cls="container", **kwargs)->FT:
-    "An HTML partial containing a `Title`, and `H1`, and any provided children"
-    return Title(title), Main(H1(title), *args, cls=cls, **kwargs)
+def Titled(title:str='FastHTML app', *args, cls="container", **kwargs)->FT:
+    "An HTML partial containing a `Title`, and `H1`, and any provided children. Use `btitle='Custom title'` to set a specific browser tab title."
+    btitle = kwargs.pop('btitle', title)
+    return Title(btitle), Main(H1(title), *args, cls=cls, **kwargs)
 
 # %% ../nbs/api/02_xtend.ipynb
 def Socials(title, site_name, description, image, url=None, w=1200, h=630, twitter_site=None, creator=None, card='summary'):

--- a/nbs/api/02_xtend.ipynb
+++ b/nbs/api/02_xtend.ipynb
@@ -502,9 +502,10 @@
    "source": [
     "#| export\n",
     "@delegates(ft_hx, keep=True)\n",
-    "def Titled(title:str=\"FastHTML app\", *args, cls=\"container\", **kwargs)->FT:\n",
-    "    \"An HTML partial containing a `Title`, and `H1`, and any provided children\"\n",
-    "    return Title(title), Main(H1(title), *args, cls=cls, **kwargs)"
+    "def Titled(title:str='FastHTML app', *args, cls=\"container\", **kwargs)->FT:\n",
+    "    \"An HTML partial containing a `Title`, and `H1`, and any provided children. Use `btitle='Custom title'` to set a specific browser tab title.\"\n",
+    "    btitle = kwargs.pop('btitle', title)\n",
+    "    return Title(btitle), Main(H1(title), *args, cls=cls, **kwargs)"
    ]
   },
   {


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Proposed Changes**
Updated the `Titled()` component to optionally accept a specific browser tab title that is different from the main H1 title.

For example in the _fasthtml-tut_ repo I'm looking to update the various example files, and it would be useful to use the modified `Titled()` component to render the filename as the browser title, and the main `H1` as it is currently.

Usage is:
```
@rt("/")
def get():
	return Titled('Main Page Heading', btitle='main.py')
```

![image](https://github.com/user-attachments/assets/cdcb4192-5b3b-4c43-a5a0-4f9ffae6b9d5)

If `btitle` is omitted then it behaves as before:
```
@rt("/")
def get():
	return Titled('Main Page Heading')
```

![image](https://github.com/user-attachments/assets/f31e902f-9346-4018-91a4-b3028af6fe6f)

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.