### PR TITLE
add missing Leave Room button in e2e tutorial

### DIFF
--- a/nbs/tutorials/e2e.ipynb
+++ b/nbs/tutorials/e2e.ipynb
@@ -273,6 +273,7 @@
     "    \"\"\"\n",
     "    \n",
     "    return Titled(f\"Room: {room.name}\",\n",
+    "                  A(Button(\"Leave Room\"), href=\"/\"),\n",
     "                  canvas,\n",
     "                  Div(color_picker, brush_size),\n",
     "                  Script(src=\"https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js\"),\n",


### PR DESCRIPTION
Missing leave room button in step by step setup of the room page.