### PR TITLE
Corrected some formatting issues

### DIFF
--- a/nbs/explains/oauth.ipynb
+++ b/nbs/explains/oauth.ipynb
@@ -50,7 +50,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div style=\"text-align: center;\"><img src=\"imgs/gh-oauth.png\" alt=\"Setting up an OAuth app in GitHub\" width=\"500\" /></div>"
+    "<div style=\"text-align:center;margin:50px 0 45px;\"><img src=\"imgs/gh-oauth.png\" alt=\"Setting up an OAuth app in GitHub\" width=\"500\" /></div>"
    ]
   },
   {
@@ -75,7 +75,8 @@
    "metadata": {},
    "source": [
     "::: {.callout-note}\n",
-    "It's recommended to store the client ID, and secret, in environment variables, rather than hardcoding them in your code.):::"
+    "It's recommended to store the client ID, and secret, in environment variables, rather than hardcoding them in your code.\n",
+    ":::"
    ]
   },
   {


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''
---

**Proposed Changes**
The recent PR merge for the OAuth docs showed a couple of formatting issues that needed to be resolved such as vertical spacing around the GitHub oauth image and the note box (see screenshot).

![image](https://github.com/user-attachments/assets/88f8d3de-42cd-47da-9944-37cb2ecfc58f)

I changed the margin values for the image based on editing the live FastHTML docs HTML via the inspector until it looked.

![image](https://github.com/user-attachments/assets/189fc18a-4d8a-4a93-9d02-aa2ab3ef9654)

Here is what it looked like before.

![image](https://github.com/user-attachments/assets/526a1a1a-7558-481a-9a0e-28700005a879)
