### PR TITLE
Bonus docs for Jupy+FH

### DIFF
--- a/nbs/tutorials/jupyter_and_fasthtml.ipynb
+++ b/nbs/tutorials/jupyter_and_fasthtml.ipynb
@@ -28,6 +28,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3f506c4a",
+   "metadata": {},
+   "source": [
+    "## Getting started"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3bdd7e4a",
    "metadata": {},
    "source": [
@@ -135,10 +143,75 @@
    "execution_count": null,
    "id": "e7d4e6fa",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<iframe src=\"http://localhost:8000\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
+       "        let frame = this;\n",
+       "        window.addEventListener('message', function(e) {\n",
+       "            if (e.data.height) frame.style.height = (e.data.height+1) + 'px';\n",
+       "        }, false);\n",
+       "    }\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Run locally, uncomment this line to display the HTMX application in Jupyter\n",
-    "# HTMX(port=port)"
+    "HTMX(port=port)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb8e5cb4",
+   "metadata": {},
+   "source": [
+    "## Refreshing the HTMX() view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "689aacfc",
+   "metadata": {},
+   "source": [
+    "If we change the above view, we don't need to run `server = JupyUvi(app, port=port)` again. All we need to do is refresh the cell that contains `HTMX(port=port)`. This also applies to other tasks like importing more Python libraries, adding functions, general debugging, and more. To try it out:\n",
+    "\n",
+    "1. Change the `Titled()` FT Component from \"Hello, Jupyter\" to say \"Hello, FastHTML\"\n",
+    "2. Refresh the Jupyter cell containing `HTMX(port=port) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fb908e6",
+   "metadata": {},
+   "source": [
+    "## Full screen view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3ee64b6",
+   "metadata": {},
+   "source": [
+    "\n",
+    "You can view your app outside of Jupyter by going to `localhost:PORT`, where `PORT` is what you set the `port` variable to. This can be useful for debugging. Unless you change the `port` value in this tutorial, just click on this link: [localhost:8000/](http://localhost:8000/).\n",
+    "\n",
+    "Understand that this is FastHTML running in Jupyter mode, so things will look different. For example, unlike `fast_app`, `jupy_app` doesn't include Picoweb CSS as a default."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b410c112",
+   "metadata": {},
+   "source": [
+    "## Graceful shutdowns"
    ]
   },
   {
@@ -146,7 +219,7 @@
    "id": "86554c9d",
    "metadata": {},
    "source": [
-    "When you want to gracefully shut down the server use the `server.stop()` function displayed below. If you restart Jupyter without calling this line the thread may not be released and the `HTMX` callable above may throw errors. If that happens, a quick temporary fix is to change the `port` number above to something else.\n",
+    "Use the `server.stop()` function displayed below. If you restart Jupyter without calling this line the thread may not be released and the `HTMX` callable above may throw errors. If that happens, a quick temporary fix is to change the `port` number above to something else.\n",
     "\n",
     "Cleaner solutions to the dangling thread are to kill the dangling thread (dependant on each operating system) or restart the computer."
    ]
@@ -163,11 +236,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "49889b3d",
+   "cell_type": "markdown",
+   "id": "d76484ec",
    "metadata": {},
-   "outputs": [],
    "source": []
   }
  ],

--- a/nbs/tutorials/jupyter_and_fasthtml.ipynb
+++ b/nbs/tutorials/jupyter_and_fasthtml.ipynb
@@ -76,7 +76,7 @@
    "id": "d24f2972",
    "metadata": {},
    "source": [
-    "Define a route to test the application."
+    "Define two view handlers to test the application."
    ]
   },
   {
@@ -89,8 +89,23 @@
     "@rt\n",
     "def index():\n",
     "    return Titled('Hello, Jupyter',\n",
-    "           P('Welcome to the FastHTML + Jupyter example')\n",
+    "        P(A('Click me to get a random number', hx_get=randomizer, hx_target='#result')),\n",
+    "        P(A('Reload this page', href=index)),   \n",
+    "        Div(id='result')                  \n",
     "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1235d755",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "@rt\n",
+    "def randomizer(): return Div(P(f'Random {random.randint(1,100)}'))"
    ]
   },
   {
@@ -143,48 +158,43 @@
    "execution_count": null,
    "id": "e7d4e6fa",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<iframe src=\"http://localhost:8000\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
-       "        let frame = this;\n",
-       "        window.addEventListener('message', function(e) {\n",
-       "            if (e.data.height) frame.style.height = (e.data.height+1) + 'px';\n",
-       "        }, false);\n",
-       "    }\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Run locally, uncomment this line to display the HTMX application in Jupyter\n",
-    "HTMX(port=port)"
+    "# HTMX(port=port)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fb8e5cb4",
+   "id": "58b979f6",
    "metadata": {},
    "source": [
-    "## Refreshing the HTMX() view"
+    "## Refreshing handlers"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "689aacfc",
+   "id": "1ec5e175",
    "metadata": {},
    "source": [
-    "If we change the above view, we don't need to run `server = JupyUvi(app, port=port)` again. All we need to do is refresh the cell that contains `HTMX(port=port)`. This also applies to other tasks like importing more Python libraries, adding functions, general debugging, and more. To try it out:\n",
+    "Just like with normal web pages, if a handler is changed we need to refresh the rendered page to see the changes. In a web app `fast_app()` does this via a websocket, but inside Jupyter after running the cell on a handler we need to take an extra step of manually updating the rendered HTML. \n",
     "\n",
-    "1. Change the `Titled()` FT Component from \"Hello, Jupyter\" to say \"Hello, FastHTML\"\n",
-    "2. Refresh the Jupyter cell containing `HTMX(port=port) "
+    "We can see this in action by following these steps:\n",
+    "\n",
+    "1. Cange the value of 'Hello, Jupyter' in the `Titled()` element to `Hello, Jupyter + FastHTML`\n",
+    "2. click the 'Reload this page' link\n",
+    "\n",
+    "You'll see the change you made appear inside the HTMX view. This happens because the line written to be `P(A('Reload this page', href=index)),` does just that - it reloads the page. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74284d75",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note title='When the HTMX() view must be refreshed'}\n",
+    "Sometimes we have to refresh the HTMX() page. This can happen when no means to refresh the page is provided. To perform this action run again the cell that contains `HTMX(port=port)`. \n",
+    ":::"
    ]
   },
   {

--- a/nbs/tutorials/jupyter_and_fasthtml.ipynb
+++ b/nbs/tutorials/jupyter_and_fasthtml.ipynb
@@ -13,7 +13,7 @@
    "id": "4b1ee344",
    "metadata": {},
    "source": [
-    "To wrote FastHTML applications in Jupyter notebooks requires a slightly different process than normal Python applications. "
+    "To write FastHTML applications in Jupyter notebooks requires a slightly different process than normal Python applications. "
    ]
   },
   {
@@ -254,9 +254,13 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] Bonus docs for Jupy+FH'
labels: 'documentation'
assignees: ''

---

**Related Issue**

#487 [DOCS] More features for the Jupyter+FastHTML demo

**Proposed Changes**

This change adds the following based on ticket #487 which is based on feedback from @jph00:

- [x] Show that we can refresh an HTMX handler by simply executing a different cell, and we don't have to restart the server or re-run HTMX() 
- [x] If you modify the home page however, you do have to re-run HTMX() (but not the server).
- [x] Mention we can go to localhost:8000 in another tab to see a full screen view.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
