### PR TITLE
Update live reload documentation

### DIFF
--- a/fasthtml/live_reload.py
+++ b/fasthtml/live_reload.py
@@ -47,7 +47,7 @@ class FastHTMLWithLiveReload(FastHTML):
         >>> app = FastHTMLWithLiveReload()
 
         Run:
-            run_uv()
+            serve()
     """
     LIVE_RELOAD_ROUTE = WebSocketRoute("/live-reload", endpoint=live_reload_websocket)
 

--- a/nbs/ref/live_reload.ipynb
+++ b/nbs/ref/live_reload.ipynb
@@ -30,7 +30,8 @@
     "**⚠️ Gotchas**\n",
     "- A reload is only triggered when you save your changes.\n",
     "- `FastHTMLWithLiveReload` should only be used during development.\n",
-    "- If your app spans multiple directories you might need to use the `--reload-dir` flag to watch all files in each directory. See the uvicorn [docs](https://www.uvicorn.org/settings/#development) for more info."
+    "- If your app spans multiple directories you might need to use the `--reload-dir` flag to watch all files in each directory. See the uvicorn [docs](https://www.uvicorn.org/settings/#development) for more info.\n",
+    "- The live reload script is only injected into the page when rendering [ft components](https://docs.fastht.ml/explains/explaining_xt_components.html)."
    ]
   },
   {

--- a/nbs/tutorials/by_example.ipynb
+++ b/nbs/tutorials/by_example.ipynb
@@ -70,12 +70,7 @@
     "INFO:     Application startup complete.\n",
     "```\n",
     "\n",
-    "If you navigate to [http://127.0.0.1:8000](http://127.0.0.1:8000) in a browser, you'll see your \"Hello, World\". If you edit the `app.py` file and save it, the server will reload and you'll see the updated message when you refresh the page in your browser.  \n",
-    "\n",
-    ":::{.callout-tip}\n",
-    "# Live Reloading\n",
-    "You can also enable [live reloading](../ref/live_reload.ipynb) so you don't have to manually refresh your browser while editing it.\n",
-    ":::"
+    "If you navigate to [http://127.0.0.1:8000](http://127.0.0.1:8000) in a browser, you'll see your \"Hello, World\". If you edit the `app.py` file and save it, the server will reload and you'll see the updated message when you refresh the page in your browser."
    ]
   },
   {
@@ -197,7 +192,12 @@
    "source": [
     "This will render the HTML in the browser.\n",
     "\n",
-    "For debugging, you can right-click on the rendered HTML in the browser and select \"Inspect\" to see the underlying HTML that was generated. There you'll also find the 'network' tab, which shows you the requests that were made to render the page. Refresh and look for the request to `127.0.0.1` - and you'll see it's just a `GET` request to `/`, and the response body is the HTML you just returned."
+    "For debugging, you can right-click on the rendered HTML in the browser and select \"Inspect\" to see the underlying HTML that was generated. There you'll also find the 'network' tab, which shows you the requests that were made to render the page. Refresh and look for the request to `127.0.0.1` - and you'll see it's just a `GET` request to `/`, and the response body is the HTML you just returned.\n",
+    "\n",
+    ":::{.callout-tip}\n",
+    "# Live Reloading\n",
+    "You can also enable [live reloading](../ref/live_reload.ipynb) so you don't have to manually refresh your browser to view updates.\n",
+    ":::"
    ]
   },
   {


### PR DESCRIPTION
The Hello World example at the beginning of the [tutorial](https://docs.fastht.ml/tutorials/by_example.html) returns a raw HTML string, so it's not compatible with live reload. For the hypothetical eager reader who follows the callout tip and enables live reloading before continuing with the tutorial, this is tricky to debug. 

Changes:
- Add a note to the Live Reload "Gotchas" section about the need to use ft components 
  - Is this the correct term? The docs seem to use "ft components", "FT components", and "FT objects" interchangeably.
- Move the live reload callout tip further down in the tutorial after components have been introduced
  - I didn't want to make any major changes to the tutorial flow, but personally I think it would be a nicer learning experience to just dive straight into components instead of starting with an example that's not _really_ a valid FastHTML app.
- Replace deprecated `run_uv()` reference in `FastHTMLWithLiveReload`

Thanks for the awesome library, looking forward to reading the rest of the tutorial! 😁 