### PR TITLE
Allow toasts to work with FtResponse

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -51,7 +51,7 @@ def render_toasts(sess):
                hx_swap_oob="afterbegin:body")
 
 def toast_after(resp, req, sess):
-    if sk in sess and (not resp or isinstance(resp, (tuple,FT))): req.injects.append(render_toasts(sess))
+    if sk in sess and (not resp or isinstance(resp, (tuple,FT,FtResponse))): req.injects.append(render_toasts(sess))
 
 def setup_toasts(app):
     app.hdrs += (Style(toast_css), Script(toast_js, type="module"))

--- a/nbs/tutorials/quickstart_for_web_devs.ipynb
+++ b/nbs/tutorials/quickstart_for_web_devs.ipynb
@@ -1280,7 +1280,7 @@
     "\n",
     "1. `setup_toasts` is a helper function that adds toast dependencies. Usually this would be declared right after `fast_app()`\n",
     "2. Toasts require sessions\n",
-    "3. Views with Toasts must return FT components."
+    "3. Views with Toasts must return FT or FtResponse components."
    ]
   },
   {

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -19,6 +19,11 @@ def post(session):
 def get(session):
     return Titled("Hello, world!", P(str(session)))
 
+@rt("/see-toast-ft-response")
+def get(session):
+    add_toast(session, "Toast FtResponse", "info")
+    return FtResponse(Titled("Hello, world!", P(str(session))))
+
 def test_get_toaster():
     cli.get('/set-toast-get', follow_redirects=False)
     res = cli.get('/see-toast')
@@ -32,6 +37,11 @@ def test_post_toaster():
     res = cli.get('/see-toast')
     assert 'Toast post' in res.text
 
+def test_ft_response():
+    res = cli.get('/see-toast-ft-response')
+    assert 'Toast FtResponse' in res.text
+
 test_get_toaster()
 test_post_toaster()
+test_ft_response()
 


### PR DESCRIPTION
---
name: Pull Request
about: Fix for issues 486
title: '[PR] Allow toasts to work with FtResponse'
labels: 'bug', 'hacktoberfest'
assignees: ''

---

**Related Issue**
[[BUG] FtResponse breaks toasts](https://github.com/AnswerDotAI/fasthtml/issues/486)

**Proposed Changes**
Add FtResponse to list of supported response types

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
