### PR TITLE
Document multiple file uploads

### DIFF
--- a/nbs/tutorials/quickstart_for_web_devs.ipynb
+++ b/nbs/tutorials/quickstart_for_web_devs.ipynb
@@ -1488,7 +1488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A common task in web development is uploading files. This example is for uploading files to the hosting server, with information about the uploaded file presented to the user.\n",
+    "A common task in web development is uploading files. This examples below are for uploading files to the hosting server, with information about the uploaded file presented to the user.\n",
     "\n",
     ":::{.callout-warning title='File uploads in production can be dangerous'}\n",
     "File uploads can be the target of abuse, accidental or intentional. That means users may attempt to upload files that are too large or present a security risk. This is especially of concern for public facing apps. File upload security is outside the scope of this tutorial, for now we suggest reading the [OWASP File Upload Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html).\n",
@@ -1496,10 +1496,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Single File Uploads"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<meta charset=\"utf-8\">\n",
+       "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\n",
+       "<script src=\"https://unpkg.com/htmx.org@next/dist/htmx.min.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.4/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css\">\n",
+       "<style>:root { --pico-font-size: 100%; }</style>\n",
+       "<script>\n",
+       "    function sendmsg() {\n",
+       "        window.parent.postMessage({height: document.documentElement.offsetHeight}, '*');\n",
+       "    }\n",
+       "    window.onload = function() {\n",
+       "        sendmsg();\n",
+       "        document.body.addEventListener('htmx:afterSettle',    sendmsg);\n",
+       "        document.body.addEventListener('htmx:wsAfterMessage', sendmsg);\n",
+       "    };</script>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from fasthtml.common import *\n",
     "from pathlib import Path\n",
@@ -1512,14 +1544,12 @@
     "@rt('/')\n",
     "def get():\n",
     "    return Titled(\"File Upload Demo\",\n",
-    "        Div(cls='grid')(\n",
-    "            Article(\n",
-    "                Form(hx_post=\"/upload\", hx_target=\"#result-one\")( # <1>\n",
-    "                    Input(type=\"file\", name=\"file\"), # <2>\n",
-    "                    Button(\"Upload\", type=\"submit\", cls='secondary'),\n",
-    "                ),\n",
-    "                Div(id=\"result-one\")\n",
-    "            )\n",
+    "        Article(\n",
+    "            Form(hx_post=upload, hx_target=\"#result-one\")( # <1>\n",
+    "                Input(type=\"file\", name=\"file\"), # <2>\n",
+    "                Button(\"Upload\", type=\"submit\", cls='secondary'),\n",
+    "            ),\n",
+    "            Div(id=\"result-one\")\n",
     "        )\n",
     "    )\n",
     "\n",
@@ -1533,8 +1563,8 @@
     "        )\n",
     "    )    \n",
     "\n",
-    "@rt('/upload')\n",
-    "async def post(file: UploadFile): # <3>\n",
+    "@rt\n",
+    "async def upload(file: UploadFile): # <3>\n",
     "    card = FileMetaDataCard(file)  # <4>\n",
     "    filebuffer = await file.read()  # <5>\n",
     "    (upload_dir / file.filename).write_bytes(filebuffer) # <6>\n",
@@ -1550,7 +1580,7 @@
     "1. Every form rendered with the `Form` FT component defaults to `enctype=\"multipart/form-data\"`\n",
     "2. Don't forget to set the `Input` FT Component's type to `file`\n",
     "3. The upload view should receive a [Starlette UploadFile](https://www.starlette.io/requests/#request-files) type. You can add other form variables\n",
-    "4. We can access the metadata of the card (filename, size, content_type, headers), a quick and safe process\n",
+    "4. We can access the metadata of the card (filename, size, content_type, headers), a quick and safe process. We set that to the card variable\n",
     "5. In order to access the contents contained within a file we use the `await` method to read() it. As files may be quite large or contain bad data, this is a seperate step from accessing metadata\n",
     "6. This step shows how to use Python's built-in `pathlib.Path` library to write the file to disk."
    ]
@@ -1558,7 +1588,95 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "### Multiple File Uploads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<meta charset=\"utf-8\">\n",
+       "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\n",
+       "<script src=\"https://unpkg.com/htmx.org@next/dist/htmx.min.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.4/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css\">\n",
+       "<style>:root { --pico-font-size: 100%; }</style>\n",
+       "<script>\n",
+       "    function sendmsg() {\n",
+       "        window.parent.postMessage({height: document.documentElement.offsetHeight}, '*');\n",
+       "    }\n",
+       "    window.onload = function() {\n",
+       "        sendmsg();\n",
+       "        document.body.addEventListener('htmx:afterSettle',    sendmsg);\n",
+       "        document.body.addEventListener('htmx:wsAfterMessage', sendmsg);\n",
+       "    };</script>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from fasthtml.common import *\n",
+    "from pathlib import Path\n",
+    "\n",
+    "app, rt = fast_app()\n",
+    "\n",
+    "upload_dir = Path(\"filez\")\n",
+    "upload_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "@rt('/')\n",
+    "def get():\n",
+    "    return Titled(\"Multiple File Upload Demo\",\n",
+    "        Article(\n",
+    "            Form(hx_post=upload_many, hx_target=\"#result-many\")( # <1>\n",
+    "                Input(type=\"file\", name=\"files\", multiple=True), # <2>\n",
+    "                Button(\"Upload\", type=\"submit\", cls='secondary'),\n",
+    "            ),\n",
+    "            Div(id=\"result-many\")\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "def FileMetaDataCard(file):\n",
+    "    return Article(\n",
+    "        Header(H3(file.filename)),\n",
+    "        Ul(\n",
+    "            Li('Size: ', file.size),            \n",
+    "            Li('Content Type: ', file.content_type),\n",
+    "            Li('Headers: ', file.headers),\n",
+    "        )\n",
+    "    )    \n",
+    "\n",
+    "@rt\n",
+    "async def upload_many(files: list[UploadFile]): # <3>\n",
+    "    cards = []\n",
+    "    for file in files:  # <4>\n",
+    "        cards.append(FileMetaDataCard(file))  # <5>\n",
+    "        filebuffer = await file.read()  # <6>\n",
+    "        (upload_dir / file.filename).write_bytes(filebuffer) # <7>\n",
+    "    return cards\n",
+    "\n",
+    "serve()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. Every form rendered with the `Form` FT component defaults to `enctype=\"multipart/form-data\"`\n",
+    "2. Don't forget to set the `Input` FT Component's type to `file` and assign the multiple attribute to `True`\n",
+    "3. The upload view should receive a `list` containing the [Starlette UploadFile](https://www.starlette.io/requests/#request-files) type. You can add other form variables\n",
+    "4. Iterate through the files\n",
+    "5. We can access the metadata of the card (filename, size, content_type, headers), a quick and safe process. We add that to the cards variable\n",
+    "6. In order to access the contents contained within a file we use the `await` method to read() it. As files may be quite large or contain bad data, this is a seperate step from accessing metadata\n",
+    "7. This step shows how to use Python's built-in `pathlib.Path` library to write the file to disk."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] Document multiple file support'
labels: 'documentation'
assignees: ''

---

**Proposed Changes**

Add documentation for multiple file uploads. Rather than a combined example, or a single file upload, it separates the single- and multi-file uploads into two examples. This approach provides several benefits:

1. Provide easy-to-copy examples that just work
2. It is easier to maintain and test these docs compared to other approaches

Note: This is a rewrite of #534 to get around a problem with rebasing and notebooks.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

