### PR TITLE
Convert quickstart Python modules to markdown

### DIFF
--- a/nbs/tutorials/quickstart_for_web_devs.ipynb
+++ b/nbs/tutorials/quickstart_for_web_devs.ipynb
@@ -1503,36 +1503,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<meta charset=\"utf-8\">\n",
-       "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\n",
-       "<script src=\"https://unpkg.com/htmx.org@next/dist/htmx.min.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.4/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css\">\n",
-       "<style>:root { --pico-font-size: 100%; }</style>\n",
-       "<script>\n",
-       "    function sendmsg() {\n",
-       "        window.parent.postMessage({height: document.documentElement.offsetHeight}, '*');\n",
-       "    }\n",
-       "    window.onload = function() {\n",
-       "        sendmsg();\n",
-       "        document.body.addEventListener('htmx:afterSettle',    sendmsg);\n",
-       "        document.body.addEventListener('htmx:wsAfterMessage', sendmsg);\n",
-       "    };</script>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
    "source": [
+    "```python\n",
     "from fasthtml.common import *\n",
     "from pathlib import Path\n",
     "\n",
@@ -1570,7 +1544,8 @@
     "    (upload_dir / file.filename).write_bytes(filebuffer) # <6>\n",
     "    return card\n",
     "\n",
-    "serve()"
+    "serve()\n",
+    "```"
    ]
   },
   {
@@ -1593,36 +1568,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<meta charset=\"utf-8\">\n",
-       "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\n",
-       "<script src=\"https://unpkg.com/htmx.org@next/dist/htmx.min.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.4/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css\">\n",
-       "<style>:root { --pico-font-size: 100%; }</style>\n",
-       "<script>\n",
-       "    function sendmsg() {\n",
-       "        window.parent.postMessage({height: document.documentElement.offsetHeight}, '*');\n",
-       "    }\n",
-       "    window.onload = function() {\n",
-       "        sendmsg();\n",
-       "        document.body.addEventListener('htmx:afterSettle',    sendmsg);\n",
-       "        document.body.addEventListener('htmx:wsAfterMessage', sendmsg);\n",
-       "    };</script>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
    "source": [
+    "```python\n",
     "from fasthtml.common import *\n",
     "from pathlib import Path\n",
     "\n",
@@ -1662,7 +1611,8 @@
     "        (upload_dir / file.filename).write_bytes(filebuffer) # <7>\n",
     "    return cards\n",
     "\n",
-    "serve()"
+    "serve()\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] Convert quickstart Python modules to markdown'
labels: 'bug,documentation'
assignees: ''

---

**Related Issue**
 
#553 Quickstart sidebars are broken

**Proposed Changes**

Change the Python segments that call `serve()` to Markdown. The `serve()` is interfering with Quarto's ability to render cells. Something likely to do with uvicorn trying to serve those segments out.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

