### PR TITLE
Make default host in port introspection functions `0.0.0.0`

### DIFF
--- a/fasthtml/jupyter.py
+++ b/fasthtml/jupyter.py
@@ -35,7 +35,7 @@ async def nb_serve_async(app, log_level="error", port=8000, host='0.0.0.0', **kw
     return server
 
 # %% ../nbs/api/06_jupyter.ipynb
-def is_port_free(port, host='localhost'):
+def is_port_free(port, host='0.0.0.0'):
     "Check if `port` is free on `host`"
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
@@ -46,7 +46,7 @@ def is_port_free(port, host='localhost'):
     finally: sock.close()
 
 # %% ../nbs/api/06_jupyter.ipynb
-def wait_port_free(port, host='localhost', max_wait=3):
+def wait_port_free(port, host='0.0.0.0', max_wait=3):
     "Wait for `port` to be free on `host`"
     start_time = time.time()
     while not is_port_free(port):

--- a/nbs/api/06_jupyter.ipynb
+++ b/nbs/api/06_jupyter.ipynb
@@ -99,7 +99,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def is_port_free(port, host='localhost'):\n",
+    "def is_port_free(port, host='0.0.0.0'):\n",
     "    \"Check if `port` is free on `host`\"\n",
     "    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n",
     "    try:\n",
@@ -118,7 +118,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def wait_port_free(port, host='localhost', max_wait=3):\n",
+    "def wait_port_free(port, host='0.0.0.0', max_wait=3):\n",
     "    \"Wait for `port` to be free on `host`\"\n",
     "    start_time = time.time()\n",
     "    while not is_port_free(port):\n",


### PR DESCRIPTION
@pydanny and I discovered that `is_port_free(5002)` was `True` even when a local FastHTML app was running on port 5002.

Changing the default `host` to `0.0.0.0` resolves it.

---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] Make default host in port introspection functions `0.0.0.0`'
labels: 'bug'
assignees: ''

---

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.
