### PR TITLE
configurable toast duration

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -13,9 +13,17 @@ toast_css = """
 }
 .fh-toast {
     background-color: #333; color: white;
-    padding: 12px 20px; border-radius: 4px; margin-bottom: 10px;
+    padding: 12px 28px 12px 20px; border-radius: 4px; margin-bottom: 10px;
     max-width: 80%; width: auto; text-align: center;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    position: relative;
+}
+.fh-toast-dismiss {
+    position:absolute; top:0.2em; right:0.4em;
+    line-height:1em; padding: 0 0.2em 0.2em 0.2em; border-radius:inherit; 
+    transform:scaleY(0.8); transform:scaleX(1.); 
+    pointer-events:auto; cursor:pointer; 
+    background-color:inherit; color:inherit; filter:brightness(0.85);
 }
 .fh-toast-info { background-color: #2196F3; }
 .fh-toast-success { background-color: #4CAF50; }
@@ -24,21 +32,25 @@ toast_css = """
 """
 
 toast_js = """
-export function proc_htmx(sel, func) {
-  htmx.onLoad(elt => {
+export function proc_htmx(sel, func) {{
+  htmx.onLoad(elt => {{
     const elements = any(sel, elt, false);
     if (elt.matches && elt.matches(sel)) elements.unshift(elt);
     elements.forEach(func);
-  });
-}
-proc_htmx('.fh-toast-container', async function(toast) {
+  }});
+}}
+proc_htmx('.fh-toast-container', async function(toast) {{
     await sleep(100);
     toast.style.opacity = '0.8';
-    await sleep(3000);
+    await sleep({duration});
     toast.style.opacity = '0';
     await sleep(300);
     toast.remove();
-});
+}});
+
+proc_htmx('.fh-toast-dismiss', function(elem) {{ 
+    elem.addEventListener('click', (e) => {{ e.target.parentElement.remove() }}); 
+}});
 """
 
 def add_toast(sess, message, typ="info"):
@@ -46,14 +58,12 @@ def add_toast(sess, message, typ="info"):
     sess.setdefault(sk, []).append((message, typ))
 
 def render_toasts(sess):
-    toasts = [Div(msg, cls=f"fh-toast fh-toast-{typ}") for msg,typ in sess.pop(sk, [])]
-    return Div(Div(*toasts, cls="fh-toast-container"),
-               hx_swap_oob="afterbegin:body")
+    toasts = [Div(msg, Span('x', cls='fh-toast-dismiss'), cls=f"fh-toast fh-toast-{typ}") for msg,typ in sess.pop(sk, [])]
+    return Div(Div(*toasts, cls="fh-toast-container"), hx_swap_oob="afterbegin:body")
 
 def toast_after(resp, req, sess):
     if sk in sess and (not resp or isinstance(resp, (tuple,FT,FtResponse))): req.injects.append(render_toasts(sess))
 
-def setup_toasts(app):
-    app.hdrs += (Style(toast_css), Script(toast_js, type="module"))
+def setup_toasts(app, duration:float=10.):
+    app.hdrs += (Style(toast_css), Script(toast_js.format(duration=1000*duration), type="module"))
     app.after.append(toast_after)
-

--- a/nbs/tutorials/quickstart_for_web_devs.ipynb
+++ b/nbs/tutorials/quickstart_for_web_devs.ipynb
@@ -1280,7 +1280,9 @@
     "\n",
     "1. `setup_toasts` is a helper function that adds toast dependencies. Usually this would be declared right after `fast_app()`\n",
     "2. Toasts require sessions\n",
-    "3. Views with Toasts must return FT or FtResponse components."
+    "3. Views with Toasts must return FT or FtResponse components.\n",
+    "\n",
+    "💡 `setup_toasts` takes a `duration` input that allows you to specify how long a toast will be visible before disappearing. For example `setup_toasts(duration=5)` sets the toasts duration to 5 seconds. By default toasts disappear after 10 seconds."
    ]
   },
   {


### PR DESCRIPTION
This PR implements the following:
- increase the default toast duration to 10 seconds
- add a `duration` param to `setup_toasts`
- add an `x` icon, that allows the user to close the toast

---
name: Configurable Toast Duration
about: Make the toast duration configurable + add an `x` icon that users can click to close the toast.
title: '[PR] '
labels: 'enhancement'
assignees: ''

---

**Related Issue**
#586 

**Proposed Changes**
#586 
tldr: this pr makes the duration of the toast configurable and increases the default duration from 3 seconds => 10 seconds. an `x` icon has also been added that allows the user to close the toast.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Here's the new icon for each toast type.

![toast_demo](https://github.com/user-attachments/assets/dad3d79a-7ac1-4339-b9d8-8abd77476dbf)

