### PR TITLE
Fix/add default title

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -392,7 +392,7 @@ def _xt_cts(req, resp):
     hdr_tags = 'title','meta','link','style','base'
     heads,bdy = partition(resp, lambda o: getattr(o, 'tag', '') in hdr_tags)
     if resp and 'hx-request' not in req.headers and not any(getattr(o, 'tag', '')=='html' for o in resp):
-        resp = respond(req, heads or [Title('FastHTML page')], bdy)
+        resp = respond(req, heads or [Title(req.app.title)], bdy)
     return _to_xml(req, resp, indent=fh_cfg.indent), http_hdrs, ts
 
 # %% ../nbs/api/00_core.ipynb
@@ -504,13 +504,14 @@ iframe_scr = Script(NotStr("""
 
 # %% ../nbs/api/00_core.ipynb
 class FastHTML(Starlette):
-    def __init__(self, debug=False, routes=None, middleware=None, exception_handlers=None,
+    def __init__(self, debug=False, routes=None, middleware=None, title: str = "FastHTML page", exception_handlers=None,
                  on_startup=None, on_shutdown=None, lifespan=None, hdrs=None, ftrs=None, exts=None,
                  before=None, after=None, surreal=True, htmx=True, default_hdrs=True, sess_cls=SessionMiddleware,
                  secret_key=None, session_cookie='session_', max_age=365*24*3600, sess_path='/',
                  same_site='lax', sess_https_only=False, sess_domain=None, key_fname='.sesskey',
                  body_wrap=noop_body, htmlkw=None, nb_hdrs=False, **bodykw):
         middleware,before,after = map(_list, (middleware,before,after))
+        self.title = title
         hdrs,ftrs,exts = map(listify, (hdrs,ftrs,exts))
         exts = {k:htmx_exts[k] for k in exts}
         htmlkw = htmlkw or {}

--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -392,7 +392,8 @@ def _xt_cts(req, resp):
     hdr_tags = 'title','meta','link','style','base'
     heads,bdy = partition(resp, lambda o: getattr(o, 'tag', '') in hdr_tags)
     if resp and 'hx-request' not in req.headers and not any(getattr(o, 'tag', '')=='html' for o in resp):
-        resp = respond(req, heads or [Title(req.app.title)], bdy)
+        title = [] if any(getattr(o, 'tag', '')=='title' for o in heads) else [Title(req.app.title)]
+        resp = respond(req, [*heads, *title], bdy)
     return _to_xml(req, resp, indent=fh_cfg.indent), http_hdrs, ts
 
 # %% ../nbs/api/00_core.ipynb

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -131,7 +131,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2024, 12, 10, 14, 0)"
+       "datetime.datetime(2024, 12, 14, 14, 0)"
       ]
      },
      "execution_count": null,
@@ -1085,7 +1085,8 @@
     "    hdr_tags = 'title','meta','link','style','base'\n",
     "    heads,bdy = partition(resp, lambda o: getattr(o, 'tag', '') in hdr_tags)\n",
     "    if resp and 'hx-request' not in req.headers and not any(getattr(o, 'tag', '')=='html' for o in resp):\n",
-    "        resp = respond(req, heads or [Title(req.app.title)], bdy)\n",
+    "        title = [] if any(getattr(o, 'tag', '')=='title' for o in heads) else [Title(req.app.title)]\n",
+    "        resp = respond(req, [*heads, *title], bdy)\n",
     "    return _to_xml(req, resp, indent=fh_cfg.indent), http_hdrs, ts"
    ]
   },
@@ -1229,7 +1230,7 @@
     {
      "data": {
       "text/plain": [
-       "'7eb16e0e-f1b9-4266-98fa-2d84c34f86fc'"
+       "'af1b5dfe-6a32-4348-b1de-692f979f20fb'"
       ]
      },
      "execution_count": null,
@@ -1665,6 +1666,59 @@
    "outputs": [],
    "source": [
     "app,cli,rt = get_cli(FastHTML(secret_key='soopersecret'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "421262a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Route(path='/foo', name='foo', methods=['GET', 'HEAD'])]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'/foo?param=value'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "app,cli,rt = get_cli(FastHTML(title=\"My Custom Title\"))\n",
+    "@app.get\n",
+    "def foo(): return Div(\"Hello World\")\n",
+    "\n",
+    "print(app.routes)\n",
+    "\n",
+    "response = cli.get('/foo')\n",
+    "assert '<title>My Custom Title</title>' in response.text\n",
+    "\n",
+    "foo.to(param='value')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ebd6270",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app,cli,rt = get_cli(FastHTML())\n",
+    "\n",
+    "@rt('/xt2')\n",
+    "def get(): return H1('bar')\n",
+    "\n",
+    "txt = cli.get('/xt2').text\n",
+    "assert '<title>FastHTML page</title>' in txt and '<h1>bar</h1>' in txt and '<html>' in txt"
    ]
   },
   {
@@ -2424,13 +2478,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Set to 2024-12-10 09:54:42.331681\n"
+      "Set to 2024-12-14 12:38:57.886589\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'Session time: 2024-12-10 09:54:42.331681'"
+       "'Session time: 2024-12-14 12:38:57.886589'"
       ]
      },
      "execution_count": null,
@@ -2950,7 +3004,7 @@
     {
      "data": {
       "text/plain": [
-       "'Cookie was set at time 09:54:43.255286'"
+       "'Cookie was set at time 12:38:58.050326'"
       ]
      },
      "execution_count": null,

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1085,7 +1085,7 @@
     "    hdr_tags = 'title','meta','link','style','base'\n",
     "    heads,bdy = partition(resp, lambda o: getattr(o, 'tag', '') in hdr_tags)\n",
     "    if resp and 'hx-request' not in req.headers and not any(getattr(o, 'tag', '')=='html' for o in resp):\n",
-    "        resp = respond(req, heads or [Title('FastHTML page')], bdy)\n",
+    "        resp = respond(req, heads or [Title(req.app.title)], bdy)\n",
     "    return _to_xml(req, resp, indent=fh_cfg.indent), http_hdrs, ts"
    ]
   },
@@ -1351,13 +1351,14 @@
    "source": [
     "#| export\n",
     "class FastHTML(Starlette):\n",
-    "    def __init__(self, debug=False, routes=None, middleware=None, exception_handlers=None,\n",
+    "    def __init__(self, debug=False, routes=None, middleware=None, title: str = \"FastHTML page\", exception_handlers=None,\n",
     "                 on_startup=None, on_shutdown=None, lifespan=None, hdrs=None, ftrs=None, exts=None,\n",
     "                 before=None, after=None, surreal=True, htmx=True, default_hdrs=True, sess_cls=SessionMiddleware,\n",
     "                 secret_key=None, session_cookie='session_', max_age=365*24*3600, sess_path='/',\n",
     "                 same_site='lax', sess_https_only=False, sess_domain=None, key_fname='.sesskey',\n",
     "                 body_wrap=noop_body, htmlkw=None, nb_hdrs=False, **bodykw):\n",
     "        middleware,before,after = map(_list, (middleware,before,after))\n",
+    "        self.title = title\n",
     "        hdrs,ftrs,exts = map(listify, (hdrs,ftrs,exts))\n",
     "        exts = {k:htmx_exts[k] for k in exts}\n",
     "        htmlkw = htmlkw or {}\n",


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
Currently, FastHTML uses a hardcoded "FastHTML page" title in the _xt_cts function. This makes it difficult for users to set their own default page titles across all pages of their app.

**Proposed Changes**
This PR adds the ability to set a custom default title for FastHTML pages and fixes title override behavior:
- Adding title parameter to FastHTML class with default value "FastHTML page"
- Updating _xt_cts to use app.title instead of hardcoded value
- Fix _xt_cts to properly respect manually passed Title components

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Usage Example**
```python
app = FastHTML(title="My Custom Title")
```

**Additional Information**
This change is backwards compatible - if no title is provided, it defaults to "FastHTML page" as before.