### PR TITLE
Suggestion: don't import uvicorn to allow for alternative asgi servers

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -11,7 +11,7 @@ __all__ = ['empty', 'htmx_hdrs', 'fh_cfg', 'htmx_resps', 'htmx_exts', 'htmxsrc',
            'MiddlewareBase', 'FtResponse', 'unqid', 'setup_ws']
 
 # %% ../nbs/api/00_core.ipynb
-import json,uuid,inspect,types,uvicorn,signal,asyncio,threading,inspect
+import json,uuid,inspect,types,signal,asyncio,threading,inspect
 
 from fastcore.utils import *
 from fastcore.xml import *
@@ -638,6 +638,7 @@ def serve(
     if not appname:
         if glb.get('__name__')=='__main__': appname = Path(glb.get('__file__', '')).stem
         elif code.co_name=='main' and bk.f_back.f_globals.get('__name__')=='__main__': appname = inspect.getmodule(bk).__name__
+    import uvicorn
     if appname:
         if not port: port=int(os.getenv("PORT", default=5001))
         print(f'Link: http://{"localhost" if host=="0.0.0.0" else host}:{port}')

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "import json,uuid,inspect,types,uvicorn,signal,asyncio,threading,inspect\n",
+    "import json,uuid,inspect,types,signal,asyncio,threading,inspect\n",
     "\n",
     "from fastcore.utils import *\n",
     "from fastcore.xml import *\n",
@@ -1582,6 +1582,7 @@
     "    if not appname:\n",
     "        if glb.get('__name__')=='__main__': appname = Path(glb.get('__file__', '')).stem\n",
     "        elif code.co_name=='main' and bk.f_back.f_globals.get('__name__')=='__main__': appname = inspect.getmodule(bk).__name__\n",
+    "    import uvicorn\n",
     "    if appname:\n",
     "        if not port: port=int(os.getenv(\"PORT\", default=5001))\n",
     "        print(f'Link: http://{\"localhost\" if host==\"0.0.0.0\" else host}:{port}')\n",


### PR DESCRIPTION
**Related Issue**

#620 

**Proposed Changes**

I'm deploying a FastHTML app to AWS Lambda, and extra imports cause longer cold starts. I did a naive test (3 samples of each) and it seems like this uvicorn import takes 10-25ms to load.

I list it as a bugfix below, but I don't think it's really a bug.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
