### PR TITLE
Handling for query or url params in qp/to

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -477,17 +477,16 @@ def _wrap_ex(f, status_code, hdrs, ftrs, htmlkw, bodykw, body_wrap):
 
 # %% ../nbs/api/00_core.ipynb
 def qp(p:str, **kw) -> str:
-    "Add query parameters to path p"
+    "Add parameters kw to path p"
     kw = {k.split(':')[0]:v for k,v in kw.items()}
-    for k,v in kw.copy().items(): # Go through all params
+    for k,v in kw.copy().items():
         for pat in [f"{{{k}}}", f"{{{k}:"]: 
-            if pat in p: # if it matches this particular pattern
-                # Put it in the path
+            if pat in p: 
+                # encode path params
                 p = p.replace(p[p.find(pat):p.find("}", p.find(pat))+1], str(v))
-                # Remove it from the query params dict
                 kw.pop(k) 
                 break
-    # Add any query params that are left
+    # encode query params
     return p + ('?' + urlencode({k:'' if v in (False,None) else v for k,v in kw.items()},doseq=True) if kw else '')
 
 # %% ../nbs/api/00_core.ipynb

--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -478,15 +478,17 @@ def _wrap_ex(f, status_code, hdrs, ftrs, htmlkw, bodykw, body_wrap):
 # %% ../nbs/api/00_core.ipynb
 def qp(p:str, **kw) -> str:
     "Add query parameters to path p"
-    kw = {k:('' if v in (False,None) else v) for k,v in kw.items()}    
-    _mods = []
-    for k,v in kw.items(): 
-        _substr=f"{{{k}}}"
-        if _substr in p:
-            _mods.append(k)
-            p = p.replace(_substr,str(v))
-    kw = {k:v for k,v in kw.items() if k not in _mods}
-    return p + ('?' + urlencode(kw,doseq=True) if kw else '')
+    kw = {k.split(':')[0]:v for k,v in kw.items()}
+    for k,v in kw.copy().items(): # Go through all params
+        for pat in [f"{{{k}}}", f"{{{k}:"]: 
+            if pat in p: # if it matches this particular pattern
+                # Put it in the path
+                p = p.replace(p[p.find(pat):p.find("}", p.find(pat))+1], str(v))
+                # Remove it from the query params dict
+                kw.pop(k) 
+                break
+    # Add any query params that are left
+    return p + ('?' + urlencode({k:'' if v in (False,None) else v for k,v in kw.items()},doseq=True) if kw else '')
 
 # %% ../nbs/api/00_core.ipynb
 def def_hdrs(htmx=True, surreal=True):

--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -478,7 +478,14 @@ def _wrap_ex(f, status_code, hdrs, ftrs, htmlkw, bodykw, body_wrap):
 # %% ../nbs/api/00_core.ipynb
 def qp(p:str, **kw) -> str:
     "Add query parameters to path p"
-    kw = {k:('' if v in (False,None) else v) for k,v in kw.items()}
+    kw = {k:('' if v in (False,None) else v) for k,v in kw.items()}    
+    _mods = []
+    for k,v in kw.items(): 
+        _substr=f"{{{k}}}"
+        if _substr in p:
+            _mods.append(k)
+            p = p.replace(_substr,str(v))
+    kw = {k:v for k,v in kw.items() if k not in _mods}
     return p + ('?' + urlencode(kw,doseq=True) if kw else '')
 
 # %% ../nbs/api/00_core.ipynb

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -131,7 +131,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2025, 1, 12, 14, 0)"
+       "datetime.datetime(2025, 1, 19, 14, 0)"
       ]
      },
      "execution_count": null,
@@ -1230,7 +1230,7 @@
     {
      "data": {
       "text/plain": [
-       "'5a5e5544-5ee8-46f2-836e-924976ce8b58'"
+       "'7293b76e-03e7-4cba-9a48-346d25aa5f32'"
       ]
      },
      "execution_count": null,
@@ -1280,8 +1280,33 @@
     "#| export\n",
     "def qp(p:str, **kw) -> str:\n",
     "    \"Add query parameters to path p\"\n",
-    "    kw = {k:('' if v in (False,None) else v) for k,v in kw.items()}\n",
+    "    kw = {k:('' if v in (False,None) else v) for k,v in kw.items()}    \n",
+    "    _mods = []\n",
+    "    for k,v in kw.items(): \n",
+    "        _substr=f\"{{{k}}}\"\n",
+    "        if _substr in p:\n",
+    "            _mods.append(k)\n",
+    "            p = p.replace(_substr,str(v))\n",
+    "    kw = {k:v for k,v in kw.items() if k not in _mods}\n",
     "    return p + ('?' + urlencode(kw,doseq=True) if kw else '')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebd2b367",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals = {'a':5, 'b':False, 'c':[1,2], 'd':'bar', 'e':None}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e51e2dc3",
+   "metadata": {},
+   "source": [
+    "`qp` adds query parameters to route path strings"
    ]
   },
   {
@@ -1293,7 +1318,7 @@
     {
      "data": {
       "text/plain": [
-       "'/foo?a=&b=&c=1&c=2&d=bar'"
+       "'/foo?a=5&b=&c=1&c=2&d=bar&e='"
       ]
      },
      "execution_count": null,
@@ -1302,7 +1327,65 @@
     }
    ],
    "source": [
-    "qp('/foo', a=None, b=False, c=[1,2], d='bar')"
+    "qp('/foo', **vals)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4740272f",
+   "metadata": {},
+   "source": [
+    "`qp` checks to see if it should be sent as a query parameter or as part of the route and encodes that properly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffbc0972",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/foo/5?b=&c=1&c=2&d=bar&e='"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qp('/foo/{a}',**vals)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c7eab51",
+   "metadata": {},
+   "source": [
+    "This works with multiple route parameters and query parmeter combinations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd4d1630",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/foo/5/bar?b=&c=1&c=2&e='"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qp('/foo/{a}/{d}', **vals)"
    ]
   },
   {
@@ -1580,13 +1663,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Route(path='/foo', name='foo', methods=['GET', 'HEAD'])]\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
        "'/foo?a=bar&b=1&b=2'"
@@ -1602,7 +1678,30 @@
     "@app.get\n",
     "def foo(a:str, b:list[int]): ...\n",
     "\n",
-    "print(app.routes)\n",
+    "foo.to(a='bar', b=[1,2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b9f1f03",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/foo/bar?b=1&b=2'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@app.get('/foo/{a}')\n",
+    "def foo(a:str, b:list[int]): ...\n",
+    "    \n",
     "foo.to(a='bar', b=[1,2])"
    ]
   },
@@ -3258,6 +3357,83 @@
     "        for o in conns.values(): await o(s)\n",
     "    app._send = send\n",
     "    return send"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd362813",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%ai\n",
+    "\n",
+    "Is there a better way to implement the `qp` function, particularly the `for k,v in kw.items()` loop?  Should this logic happen somewhere else so it's not all string replacement stuff?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e6b7e02",
+   "metadata": {},
+   "source": [
+    "Looking at the `qp` function's implementation, there are a few potential improvements we could make:\n",
+    "\n",
+    "1. The string replacement approach is error-prone since it doesn't handle nested URL parameters properly and could accidentally replace substrings that happen to match parameter names.\n",
+    "\n",
+    "2. We could use Starlette's built-in URL path building functionality instead of doing string manipulation ourselves.\n",
+    "\n",
+    "Here's a suggested improved implementation:\n",
+    "\n",
+    "```python\n",
+    "def qp(p:str, **kw) -> str:\n",
+    "    \"Add query parameters to path p\"\n",
+    "    # Handle empty/false values\n",
+    "    kw = {k:('' if v in (False,None) else v) for k,v in kw.items()}\n",
+    "    \n",
+    "    # Split path into base and any existing query params\n",
+    "    base,_,existing = p.partition('?')\n",
+    "    \n",
+    "    # Use Starlette's URL builder for path params\n",
+    "    if '{' in base:\n",
+    "        path_params = {}\n",
+    "        query_params = {}\n",
+    "        for k,v in kw.items():\n",
+    "            if f'{{{k}}}' in base: path_params[k] = v\n",
+    "            else: query_params[k] = v\n",
+    "        base = base.format(**path_params)\n",
+    "        kw = query_params\n",
+    "    \n",
+    "    # Combine query params\n",
+    "    query = urlencode(kw, doseq=True)\n",
+    "    if existing: query = f'{existing}&{query}'\n",
+    "    \n",
+    "    return f'{base}{\"?\" if query else \"\"}{query}'\n",
+    "```\n",
+    "\n",
+    "This improved version:\n",
+    "\n",
+    "1. Properly handles path parameters using Python's string formatting\n",
+    "2. Preserves any existing query parameters in the path\n",
+    "3. Clearly separates path parameter substitution from query parameter addition\n",
+    "4. Still maintains the empty value handling for False/None values\n",
+    "5. Uses `doseq=True` for proper list parameter handling\n",
+    "\n",
+    "You could test it with:\n",
+    "\n",
+    "```python\n",
+    "assert qp('/foo/{a}', a=5, b=None) == '/foo/5?b='\n",
+    "assert qp('/foo/{a}/{d}', **vals) == '/foo/5/bar?b=&c=1&c=2&e='\n",
+    "assert qp('/foo?x=1', y=2) == '/foo?x=1&y=2'\n",
+    "```\n",
+    "\n",
+    "This implementation is more robust while still being relatively simple. The main improvement is properly handling path parameters using Python's string formatting rather than trying to detect and replace them manually.\n",
+    "\n",
+    "The logic belongs in this function rather than elsewhere because:\n",
+    "1. It's a URL utility function specifically for combining paths and parameters\n",
+    "2. It needs to handle both path and query parameters in a coordinated way\n",
+    "3. The implementation is self-contained and doesn't require external state\n",
+    "\n",
+    "Would you like me to explain any part of this in more detail?"
    ]
   },
   {

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -131,7 +131,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2025, 1, 19, 14, 0)"
+       "datetime.datetime(2025, 1, 30, 14, 0)"
       ]
      },
      "execution_count": null,
@@ -1273,32 +1273,57 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fde249fb",
+   "id": "271b920a",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
     "def qp(p:str, **kw) -> str:\n",
     "    \"Add query parameters to path p\"\n",
-    "    kw = {k:('' if v in (False,None) else v) for k,v in kw.items()}    \n",
-    "    _mods = []\n",
-    "    for k,v in kw.items(): \n",
-    "        _substr=f\"{{{k}}}\"\n",
-    "        if _substr in p:\n",
-    "            _mods.append(k)\n",
-    "            p = p.replace(_substr,str(v))\n",
-    "    kw = {k:v for k,v in kw.items() if k not in _mods}\n",
-    "    return p + ('?' + urlencode(kw,doseq=True) if kw else '')"
+    "    kw = {k.split(':')[0]:v for k,v in kw.items()}\n",
+    "    for k,v in kw.copy().items(): # Go through all params\n",
+    "        for pat in [f\"{{{k}}}\", f\"{{{k}:\"]: \n",
+    "            if pat in p: # if it matches this particular pattern\n",
+    "                # Put it in the path\n",
+    "                p = p.replace(p[p.find(pat):p.find(\"}\", p.find(pat))+1], str(v))\n",
+    "                # Remove it from the query params dict\n",
+    "                kw.pop(k) \n",
+    "                break\n",
+    "    # Add any query params that are left\n",
+    "    return p + ('?' + urlencode({k:'' if v in (False,None) else v for k,v in kw.items()},doseq=True) if kw else '')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebd2b367",
+   "id": "40507fbf",
    "metadata": {},
    "outputs": [],
    "source": [
     "vals = {'a':5, 'b':False, 'c':[1,2], 'd':'bar', 'e':None, 'ab:cd':42}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bd3945d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/foo/5/bar/42?b=&c=1&c=2&e='"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res = qp('/foo/{a}/{d}/{ab:int}', **vals)\n",
+    "assert res == '/foo/5/bar/42?b=&c=1&c=2&e='\n",
+    "res"
    ]
   },
   {
@@ -1318,7 +1343,7 @@
     {
      "data": {
       "text/plain": [
-       "'/foo?a=5&b=&c=1&c=2&d=bar&e=&ab%3Acd=42'"
+       "'/foo?a=5&b=&c=1&c=2&d=bar&e=&ab=42'"
       ]
      },
      "execution_count": null,
@@ -1328,7 +1353,7 @@
    ],
    "source": [
     "res = qp('/foo', **vals)\n",
-    "assert res == '/foo?a=5&b=&c=1&c=2&d=bar&e=&ab%3Acd=42'\n",
+    "assert res == '/foo?a=5&b=&c=1&c=2&d=bar&e=&ab=42'\n",
     "res"
    ]
   },
@@ -1349,7 +1374,7 @@
     {
      "data": {
       "text/plain": [
-       "'/foo/5/bar?b=&c=1&c=2&e=&ab%3Acd=42'"
+       "'/foo/5/bar?b=&c=1&c=2&e=&ab=42'"
       ]
      },
      "execution_count": null,
@@ -1359,7 +1384,7 @@
    ],
    "source": [
     "res = qp('/foo/{a}/{d}', **vals)\n",
-    "assert res == '/foo/5/bar?b=&c=1&c=2&e=&ab%3Acd=42'\n",
+    "assert res == '/foo/5/bar?b=&c=1&c=2&e=&ab=42'\n",
     "res"
    ]
   },
@@ -1381,7 +1406,7 @@
     }
    ],
    "source": [
-    "res = qp('/foo/{a}/{d}/{ab:cd}', **vals)\n",
+    "res = qp('/foo/{a}/{d}/{ab:int}', **vals)\n",
     "assert res == '/foo/5/bar/42?b=&c=1&c=2&e='\n",
     "res"
    ]

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1327,7 +1327,9 @@
     }
    ],
    "source": [
-    "qp('/foo', **vals)"
+    "res = qp('/foo', **vals)\n",
+    "assert res == '/foo?a=5&b=&c=1&c=2&d=bar&e='\n",
+    "res"
    ]
   },
   {
@@ -1356,7 +1358,8 @@
     }
    ],
    "source": [
-    "qp('/foo/{a}',**vals)"
+    "res = qp('/foo/{a}',**vals)\n",
+    "assert res == '/foo/5?b=&c=1&c=2&d=bar&e='"
    ]
   },
   {
@@ -1385,7 +1388,9 @@
     }
    ],
    "source": [
-    "qp('/foo/{a}/{d}', **vals)"
+    "res = qp('/foo/{a}/{d}', **vals)\n",
+    "assert res == '/foo/5/bar?b=&c=1&c=2&e='\n",
+    "res"
    ]
   },
   {
@@ -3357,83 +3362,6 @@
     "        for o in conns.values(): await o(s)\n",
     "    app._send = send\n",
     "    return send"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bd362813",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%ai\n",
-    "\n",
-    "Is there a better way to implement the `qp` function, particularly the `for k,v in kw.items()` loop?  Should this logic happen somewhere else so it's not all string replacement stuff?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3e6b7e02",
-   "metadata": {},
-   "source": [
-    "Looking at the `qp` function's implementation, there are a few potential improvements we could make:\n",
-    "\n",
-    "1. The string replacement approach is error-prone since it doesn't handle nested URL parameters properly and could accidentally replace substrings that happen to match parameter names.\n",
-    "\n",
-    "2. We could use Starlette's built-in URL path building functionality instead of doing string manipulation ourselves.\n",
-    "\n",
-    "Here's a suggested improved implementation:\n",
-    "\n",
-    "```python\n",
-    "def qp(p:str, **kw) -> str:\n",
-    "    \"Add query parameters to path p\"\n",
-    "    # Handle empty/false values\n",
-    "    kw = {k:('' if v in (False,None) else v) for k,v in kw.items()}\n",
-    "    \n",
-    "    # Split path into base and any existing query params\n",
-    "    base,_,existing = p.partition('?')\n",
-    "    \n",
-    "    # Use Starlette's URL builder for path params\n",
-    "    if '{' in base:\n",
-    "        path_params = {}\n",
-    "        query_params = {}\n",
-    "        for k,v in kw.items():\n",
-    "            if f'{{{k}}}' in base: path_params[k] = v\n",
-    "            else: query_params[k] = v\n",
-    "        base = base.format(**path_params)\n",
-    "        kw = query_params\n",
-    "    \n",
-    "    # Combine query params\n",
-    "    query = urlencode(kw, doseq=True)\n",
-    "    if existing: query = f'{existing}&{query}'\n",
-    "    \n",
-    "    return f'{base}{\"?\" if query else \"\"}{query}'\n",
-    "```\n",
-    "\n",
-    "This improved version:\n",
-    "\n",
-    "1. Properly handles path parameters using Python's string formatting\n",
-    "2. Preserves any existing query parameters in the path\n",
-    "3. Clearly separates path parameter substitution from query parameter addition\n",
-    "4. Still maintains the empty value handling for False/None values\n",
-    "5. Uses `doseq=True` for proper list parameter handling\n",
-    "\n",
-    "You could test it with:\n",
-    "\n",
-    "```python\n",
-    "assert qp('/foo/{a}', a=5, b=None) == '/foo/5?b='\n",
-    "assert qp('/foo/{a}/{d}', **vals) == '/foo/5/bar?b=&c=1&c=2&e='\n",
-    "assert qp('/foo?x=1', y=2) == '/foo?x=1&y=2'\n",
-    "```\n",
-    "\n",
-    "This implementation is more robust while still being relatively simple. The main improvement is properly handling path parameters using Python's string formatting rather than trying to detect and replace them manually.\n",
-    "\n",
-    "The logic belongs in this function rather than elsewhere because:\n",
-    "1. It's a URL utility function specifically for combining paths and parameters\n",
-    "2. It needs to handle both path and query parameters in a coordinated way\n",
-    "3. The implementation is self-contained and doesn't require external state\n",
-    "\n",
-    "Would you like me to explain any part of this in more detail?"
    ]
   },
   {

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1298,7 +1298,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vals = {'a':5, 'b':False, 'c':[1,2], 'd':'bar', 'e':None}"
+    "vals = {'a':5, 'b':False, 'c':[1,2], 'd':'bar', 'e':None, 'ab:cd':42}"
    ]
   },
   {
@@ -1318,7 +1318,7 @@
     {
      "data": {
       "text/plain": [
-       "'/foo?a=5&b=&c=1&c=2&d=bar&e='"
+       "'/foo?a=5&b=&c=1&c=2&d=bar&e=&ab%3Acd=42'"
       ]
      },
      "execution_count": null,
@@ -1328,7 +1328,7 @@
    ],
    "source": [
     "res = qp('/foo', **vals)\n",
-    "assert res == '/foo?a=5&b=&c=1&c=2&d=bar&e='\n",
+    "assert res == '/foo?a=5&b=&c=1&c=2&d=bar&e=&ab%3Acd=42'\n",
     "res"
    ]
   },
@@ -1343,43 +1343,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffbc0972",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/foo/5?b=&c=1&c=2&d=bar&e='"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "res = qp('/foo/{a}',**vals)\n",
-    "assert res == '/foo/5?b=&c=1&c=2&d=bar&e='"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4c7eab51",
-   "metadata": {},
-   "source": [
-    "This works with multiple route parameters and query parmeter combinations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "bd4d1630",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'/foo/5/bar?b=&c=1&c=2&e='"
+       "'/foo/5/bar?b=&c=1&c=2&e=&ab%3Acd=42'"
       ]
      },
      "execution_count": null,
@@ -1389,7 +1359,30 @@
    ],
    "source": [
     "res = qp('/foo/{a}/{d}', **vals)\n",
-    "assert res == '/foo/5/bar?b=&c=1&c=2&e='\n",
+    "assert res == '/foo/5/bar?b=&c=1&c=2&e=&ab%3Acd=42'\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85a243b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/foo/5/bar/42?b=&c=1&c=2&e='"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res = qp('/foo/{a}/{d}/{ab:cd}', **vals)\n",
+    "assert res == '/foo/5/bar/42?b=&c=1&c=2&e='\n",
     "res"
    ]
   },

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1279,17 +1279,16 @@
    "source": [
     "#| export\n",
     "def qp(p:str, **kw) -> str:\n",
-    "    \"Add query parameters to path p\"\n",
+    "    \"Add parameters kw to path p\"\n",
     "    kw = {k.split(':')[0]:v for k,v in kw.items()}\n",
-    "    for k,v in kw.copy().items(): # Go through all params\n",
+    "    for k,v in kw.copy().items():\n",
     "        for pat in [f\"{{{k}}}\", f\"{{{k}:\"]: \n",
-    "            if pat in p: # if it matches this particular pattern\n",
-    "                # Put it in the path\n",
+    "            if pat in p: \n",
+    "                # encode path params\n",
     "                p = p.replace(p[p.find(pat):p.find(\"}\", p.find(pat))+1], str(v))\n",
-    "                # Remove it from the query params dict\n",
     "                kw.pop(k) \n",
     "                break\n",
-    "    # Add any query params that are left\n",
+    "    # encode query params\n",
     "    return p + ('?' + urlencode({k:'' if v in (False,None) else v for k,v in kw.items()},doseq=True) if kw else '')"
    ]
   },


### PR DESCRIPTION
---
name: Pull Request
about: Allow qp (and therefore `.to` method) to handle params with `?a=1` or `/a` situations
title: '[qp improvement] '
labels: 'enhancement'
assignees: 'isaac-flath'

---

**Related Issue**
[Please link to the issue that this pull request addresses. If there isn't one, please create an issue first.
](https://github.com/AnswerDotAI/fasthtml/issues/637)

**Proposed Changes**
Allow qp (and therefore `.to` method) to handle params with `?a=1` or `/a` situations

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
