### PR TITLE
handlers.ipynb : fix typo

### DIFF
--- a/nbs/ref/handlers.ipynb
+++ b/nbs/ref/handlers.ipynb
@@ -296,7 +296,7 @@
    "id": "bfbaa72c",
    "metadata": {},
    "source": [
-    "The `rt` decorator modifies the `yoyo` function by adding an `rt()` method. This method returns the route path associated with the handler. It's a convenient way to reference the route of a handler function dynamically.\n",
+    "The `rt` decorator modifies the `yoyo` function by adding a `to()` method. This method returns the route path associated with the handler. It's a convenient way to reference the route of a handler function dynamically.\n",
     "\n",
     "In the example, `yoyo.to()` is used as the value for `hx_post`. This means when the div is clicked, it will trigger an HTMX POST request to the route of the `yoyo` handler. This approach allows for flexible, DRY code by avoiding hardcoded route strings and automatically updating if the route changes.\n",
     "\n",


### PR DESCRIPTION
Fix typo in docs. Reference `to()` instead of `rt()`.