### PR TITLE
docs: update documentation links and add tutorials to optional section

### DIFF
--- a/fasthtml/core.pyi
+++ b/fasthtml/core.pyi
@@ -1,6 +1,6 @@
 """The `FastHTML` subclass of `Starlette`, along with the `RouterX` and `RouteX` classes it automatically uses."""
 __all__ = ['empty', 'htmx_hdrs', 'fh_cfg', 'htmx_resps', 'htmx_exts', 'htmxsrc', 'fhjsscr', 'surrsrc', 'scopesrc', 'viewport', 'charset', 'cors_allow', 'iframe_scr', 'all_meths', 'parsed_date', 'snake2hyphens', 'HtmxHeaders', 'HttpHeader', 'HtmxResponseHeaders', 'form2dict', 'parse_form', 'flat_xt', 'Beforeware', 'EventStream', 'signal_shutdown', 'uri', 'decode_uri', 'flat_tuple', 'noop_body', 'respond', 'Redirect', 'get_key', 'qp', 'def_hdrs', 'FastHTML', 'nested_name', 'serve', 'Client', 'RouteFuncs', 'APIRouter', 'cookie', 'reg_re_param', 'MiddlewareBase', 'FtResponse', 'unqid', 'setup_ws']
-import json, uuid, inspect, types, uvicorn, signal, asyncio, threading, inspect
+import json, uuid, inspect, types, signal, asyncio, threading, inspect
 from fastcore.utils import *
 from fastcore.xml import *
 from fastcore.meta import use_kwargs_dict
@@ -222,7 +222,7 @@ def _wrap_ex(f, status_code, hdrs, ftrs, htmlkw, bodykw, body_wrap):
     ...
 
 def qp(p: str, **kw) -> str:
-    """Add query parameters to path p"""
+    """Add parameters kw to path p"""
     ...
 
 def def_hdrs(htmx=True, surreal=True):

--- a/nbs/apilist.txt
+++ b/nbs/apilist.txt
@@ -91,7 +91,7 @@
     - `def __response__(self, req)`
 
 - `def qp(p, **kw)`
-    Add query parameters to path p
+    Add parameters kw to path p
 
 - `def def_hdrs(htmx, surreal)`
     Default headers for a FastHTML app
@@ -202,6 +202,13 @@
     Start and stop a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`
 
     - `def __init__(self, app, log_level, host, port, start, **kwargs)`
+    - `def start(self)`
+    - `def stop(self)`
+
+- `class JupyUviAsync`
+    Start and stop an async Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`
+
+    - `def __init__(self, app, log_level, host, port, **kwargs)`
     - `def start(self)`
     - `def stop(self)`
 

--- a/nbs/llms-ctx-full.txt
+++ b/nbs/llms-ctx-full.txt
@@ -60,9 +60,8 @@ write a properly formed web page. You’ll soon see the power of this
 approach.
 
 Line 9  
-The
-[`serve()`](https://AnswerDotAI.github.io/fasthtml/api/core.html#serve)
-utility configures and runs FastHTML using a library called `uvicorn`.
+The [`serve()`](https://docs.fastht.ml/api/core.html#serve) utility
+configures and runs FastHTML using a library called `uvicorn`.
 
 Run the code:
 
@@ -103,10 +102,9 @@ the image below:
 
 ## A Minimal Charting Application
 
-The
-[`Script`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#script)
-function allows you to include JavaScript. You can use Python to
-generate parts of your JS or JSON like this:
+The [`Script`](https://docs.fastht.ml/api/xtend.html#script) function
+allows you to include JavaScript. You can use Python to generate parts
+of your JS or JSON like this:
 
 ``` python
 import json
@@ -348,14 +346,13 @@ This will generate an HTML `<link>` tag for sourcing the css for Sakura.
 
 Line 8  
 If you want an inline styles, the
-[`Style()`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#style)
-function will put the result into the HTML.
+[`Style()`](https://docs.fastht.ml/api/xtend.html#style) function will
+put the result into the HTML.
 
 ## Other Static Media File Locations
 
-As you saw,
-[`Script`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#script)
-and `Link` are specific to the most common static media use cases in web
+As you saw, [`Script`](https://docs.fastht.ml/api/xtend.html#script) and
+`Link` are specific to the most common static media use cases in web
 apps: including JavaScript, CSS, and images. But it also works with
 videos and other static media files. The default behavior is to look for
 these files in the root directory - typically we don’t do anything
@@ -614,7 +611,7 @@ profile
     Profile(email='john@example.com', phone='123456789', age=5)
 
 Then add that data to the `profile_form` using FastHTML’s
-[`fill_form`](https://AnswerDotAI.github.io/fasthtml/api/components.html#fill_form)
+[`fill_form`](https://docs.fastht.ml/api/components.html#fill_form)
 class:
 
 ``` python
@@ -816,8 +813,8 @@ serve()
 ## Cookies
 
 We can set cookies using the
-[`cookie()`](https://AnswerDotAI.github.io/fasthtml/api/core.html#cookie)
-function. In our example, we’ll create a `timestamp` cookie.
+[`cookie()`](https://docs.fastht.ml/api/core.html#cookie) function. In
+our example, we’ll create a `timestamp` cookie.
 
 ``` python
 from datetime import datetime
@@ -947,10 +944,9 @@ def user_auth_before(req, sess):
 ```
 
 Now we pass our `user_auth_before` function as the first argument into a
-[`Beforeware`](https://AnswerDotAI.github.io/fasthtml/api/core.html#beforeware)
-class. We also pass a list of regular expressions to the `skip`
-argument, designed to allow users to still get to the home and login
-pages.
+[`Beforeware`](https://docs.fastht.ml/api/core.html#beforeware) class.
+We also pass a list of regular expressions to the `skip` argument,
+designed to allow users to still get to the home and login pages.
 
 ``` python
 beforeware = Beforeware(
@@ -1037,7 +1033,7 @@ that plugs nicely into HTMX in the browser
 
 Line 26  
 The endpoint view needs to be an async function that returns a
-[`EventStream`](https://AnswerDotAI.github.io/fasthtml/api/core.html#eventstream)
+[`EventStream`](https://docs.fastht.ml/api/core.html#eventstream)
 
 ## Websockets
 
@@ -1204,8 +1200,8 @@ serve()
 
 Line 13  
 Every form rendered with the
-[`Form`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#form) FT
-component defaults to `enctype="multipart/form-data"`
+[`Form`](https://docs.fastht.ml/api/xtend.html#form) FT component
+defaults to `enctype="multipart/form-data"`
 
 Line 14  
 Don’t forget to set the `Input` FT Component’s type to `file`
@@ -1275,8 +1271,8 @@ serve()
 
 Line 13  
 Every form rendered with the
-[`Form`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#form) FT
-component defaults to `enctype="multipart/form-data"`
+[`Form`](https://docs.fastht.ml/api/xtend.html#form) FT component
+defaults to `enctype="multipart/form-data"`
 
 Line 14  
 Don’t forget to set the `Input` FT Component’s type to `file` and assign
@@ -2567,7 +2563,7 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
     - `def __response__(self, req)`
 
 - `def qp(p, **kw)`
-    Add query parameters to path p
+    Add parameters kw to path p
 
 - `def def_hdrs(htmx, surreal)`
     Default headers for a FastHTML app
@@ -2678,6 +2674,13 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
     Start and stop a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`
 
     - `def __init__(self, app, log_level, host, port, start, **kwargs)`
+    - `def start(self)`
+    - `def stop(self)`
+
+- `class JupyUviAsync`
+    Start and stop an async Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`
+
+    - `def __init__(self, app, log_level, host, port, **kwargs)`
     - `def start(self)`
     - `def stop(self)`
 
@@ -4854,4 +4857,6953 @@ async def test_app() -> None:
         r = await client.get("/")
         assert r.status_code == 200
         assert r.text == "Hello World!"
-```</doc></optional></project>
+```</doc><doc title="JS App Walkthrough" desc="An end-to-end walkthrough of a complete FastHTML app, including deployment to railway."># JS App Walkthrough
+
+
+
+## Installation
+
+You’ll need the following software to complete the tutorial, read on for
+specific installation instructions:
+
+1.  Python
+2.  A Python package manager such as pip (which normally comes with
+    Python) or uv
+3.  FastHTML
+4.  Web browser
+5.  Railway.app account
+
+If you haven’t worked with Python before, we recommend getting started
+with [Miniconda](https://docs.anaconda.com/miniconda/).
+
+Note that you will only need to follow the steps in the installation
+section once per environment. If you create a new repo, you won’t need
+to redo these.
+
+### Install FastHTML
+
+For Mac, Windows and Linux, enter:
+
+``` sh
+pip install python-fasthtml
+```
+
+## First steps
+
+By the end of this section you’ll have your own FastHTML website with
+tests deployed to railway.app.
+
+### Create a hello world
+
+Create a new folder to organize all the files for your project. Inside
+this folder, create a file called `main.py` and add the following code
+to it:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+from fasthtml.common import *
+
+app = FastHTML()
+rt = app.route
+
+@rt('/')
+def get():
+    return 'Hello, world!'
+
+serve()
+```
+
+</div>
+
+Finally, run `python main.py` in your terminal and open your browser to
+the ‘Link’ that appears.
+
+### QuickDraw: A FastHTML Adventure 🎨✨
+
+The end result of this tutorial will be QuickDraw, a real-time
+collaborative drawing app using FastHTML. Here is what the final site
+will look like:
+
+<figure>
+<img src="imgs/quickdraw.png" alt="QuickDraw" />
+<figcaption aria-hidden="true">QuickDraw</figcaption>
+</figure>
+
+#### Drawing Rooms
+
+Drawing rooms are the core concept of our application. Each room
+represents a separate drawing space where a user can let their inner
+Picasso shine. Here’s a detailed breakdown:
+
+1.  Room Creation and Storage
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+db = database('data/drawapp.db')
+rooms = db.t.rooms
+if rooms not in db.t:
+    rooms.create(id=int, name=str, created_at=str, pk='id')
+Room = rooms.dataclass()
+
+@patch
+def __ft__(self:Room):
+    return Li(A(self.name, href=f"/rooms/{self.id}"))
+```
+
+</div>
+
+Or you can use our `fast_app` function to create a FastHTML app with a
+SQLite database and dataclass in one line:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+def render(room):
+    return Li(A(room.name, href=f"/rooms/{room.id}"))
+
+app,rt,rooms,Room = fast_app('data/drawapp.db', render=render, id=int, name=str, created_at=str, pk='id')
+```
+
+</div>
+
+We are specifying a render function to convert our dataclass into HTML,
+which is the same as extending the `__ft__` method from the `patch`
+decorator we used before. We will use this method for the rest of the
+tutorial since it is a lot cleaner and easier to read.
+
+- We’re using a SQLite database (via FastLite) to store our rooms.
+- Each room has an id (integer), a name (string), and a created_at
+  timestamp (string).
+- The Room dataclass is automatically generated based on this structure.
+
+2.  Creating a room
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+@rt("/")
+def get():
+    # The 'Input' id defaults to the same as the name, so you can omit it if you wish
+    create_room = Form(Input(id="name", name="name", placeholder="New Room Name"),
+                       Button("Create Room"),
+                       hx_post="/rooms", hx_target="#rooms-list", hx_swap="afterbegin")
+    rooms_list = Ul(*rooms(order_by='id DESC'), id='rooms-list')
+    return Titled("DrawCollab", 
+                  H1("DrawCollab"),
+                  create_room, rooms_list)
+
+@rt("/rooms")
+async def post(room:Room):
+    room.created_at = datetime.now().isoformat()
+    return rooms.insert(room)
+```
+
+</div>
+
+- When a user submits the “Create Room” form, this route is called.
+- It creates a new Room object, sets the creation time, and inserts it
+  into the database.
+- It returns an HTML list item with a link to the new room, which is
+  dynamically added to the room list on the homepage thanks to HTMX.
+
+3.  Let’s give our rooms shape
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+@rt("/rooms/{id}")
+async def get(id:int):
+    room = rooms[id]
+    return Titled(f"Room: {room.name}", H1(f"Welcome to {room.name}"), A(Button("Leave Room"), href="/"))
+```
+
+</div>
+
+- This route renders the interface for a specific room.
+- It fetches the room from the database and renders a title, heading,
+  and paragraph.
+
+Here is the full code so far:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+from fasthtml.common import *
+from datetime import datetime
+
+def render(room):
+    return Li(A(room.name, href=f"/rooms/{room.id}"))
+
+app,rt,rooms,Room = fast_app('data/drawapp.db', render=render, id=int, name=str, created_at=str, pk='id')
+
+@rt("/")
+def get():
+    create_room = Form(Input(id="name", name="name", placeholder="New Room Name"),
+                       Button("Create Room"),
+                       hx_post="/rooms", hx_target="#rooms-list", hx_swap="afterbegin")
+    rooms_list = Ul(*rooms(order_by='id DESC'), id='rooms-list')
+    return Titled("DrawCollab", create_room, rooms_list)
+
+@rt("/rooms")
+async def post(room:Room):
+    room.created_at = datetime.now().isoformat()
+    return rooms.insert(room)
+
+@rt("/rooms/{id}")
+async def get(id:int):
+    room = rooms[id]
+    return Titled(f"Room: {room.name}", H1(f"Welcome to {room.name}"), A(Button("Leave Room"), href="/"))
+
+serve()
+```
+
+</div>
+
+Now run `python main.py` in your terminal and open your browser to the
+‘Link’ that appears. You should see a page with a form to create a new
+room and a list of existing rooms.
+
+#### The Canvas - Let’s Get Drawing! 🖌️
+
+Time to add the actual drawing functionality. We’ll use Fabric.js for
+this:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+# ... (keep the previous imports and database setup)
+
+@rt("/rooms/{id}")
+async def get(id:int):
+    room = rooms[id]
+    canvas = Canvas(id="canvas", width="800", height="600")
+    color_picker = Input(type="color", id="color-picker", value="#3CDD8C")
+    brush_size = Input(type="range", id="brush-size", min="1", max="50", value="10")
+    
+    js = """
+    var canvas = new fabric.Canvas('canvas');
+    canvas.isDrawingMode = true;
+    canvas.freeDrawingBrush.color = '#3CDD8C';
+    canvas.freeDrawingBrush.width = 10;
+    
+    document.getElementById('color-picker').onchange = function() {
+        canvas.freeDrawingBrush.color = this.value;
+    };
+    
+    document.getElementById('brush-size').oninput = function() {
+        canvas.freeDrawingBrush.width = parseInt(this.value, 10);
+    };
+    """
+    
+    return Titled(f"Room: {room.name}",
+                  A(Button("Leave Room"), href="/"),
+                  canvas,
+                  Div(color_picker, brush_size),
+                  Script(src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js"),
+                  Script(js))
+
+# ... (keep the serve() part)
+```
+
+</div>
+
+Now we’ve got a drawing canvas! FastHTML makes it easy to include
+external libraries and add custom JavaScript.
+
+#### Saving and Loading Canvases 💾
+
+Now that we have a working drawing canvas, let’s add the ability to save
+and load drawings. We’ll modify our database schema to include a
+`canvas_data` field, and add new routes for saving and loading canvas
+data. Here’s how we’ll update our code:
+
+1.  Modify the database schema:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+app,rt,rooms,Room = fast_app('data/drawapp.db', render=render, id=int, name=str, created_at=str, canvas_data=str, pk='id')
+```
+
+</div>
+
+2.  Add a save button that grabs the canvas’ state and sends it to the
+    server:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+@rt("/rooms/{id}")
+async def get(id:int):
+    room = rooms[id]
+    canvas = Canvas(id="canvas", width="800", height="600")
+    color_picker = Input(type="color", id="color-picker", value="#3CDD8C")
+    brush_size = Input(type="range", id="brush-size", min="1", max="50", value="10")
+    save_button = Button("Save Canvas", id="save-canvas", hx_post=f"/rooms/{id}/save", hx_vals="js:{canvas_data: JSON.stringify(canvas.toJSON())}")
+    # ... (rest of the function remains the same)
+```
+
+</div>
+
+3.  Add routes for saving and loading canvas data:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+@rt("/rooms/{id}/save")
+async def post(id:int, canvas_data:str):
+    rooms.update({'canvas_data': canvas_data}, id)
+    return "Canvas saved successfully"
+
+@rt("/rooms/{id}/load")
+async def get(id:int):
+    room = rooms[id]
+    return room.canvas_data if room.canvas_data else "{}"
+```
+
+</div>
+
+4.  Update the JavaScript to load existing canvas data:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` javascript
+js = f"""
+    var canvas = new fabric.Canvas('canvas');
+    canvas.isDrawingMode = true;
+    canvas.freeDrawingBrush.color = '#3CDD8C';
+    canvas.freeDrawingBrush.width = 10;
+    // Load existing canvas data
+    fetch(`/rooms/{id}/load`)
+    .then(response => response.json())
+    .then(data => {{
+        if (data && Object.keys(data).length > 0) {{
+            canvas.loadFromJSON(data, canvas.renderAll.bind(canvas));
+        }}
+    }});
+    
+    // ... (rest of the JavaScript remains the same)
+"""
+```
+
+</div>
+
+With these changes, users can now save their drawings and load them when
+they return to the room. The canvas data is stored as a JSON string in
+the database, allowing for easy serialization and deserialization. Try
+it out! Create a new room, make a drawing, save it, and then reload the
+page. You should see your drawing reappear, ready for further editing.
+
+Here is the completed code:
+
+<div class="code-with-filename">
+
+**main.py**
+
+``` python
+from fasthtml.common import *
+from datetime import datetime
+
+def render(room):
+    return Li(A(room.name, href=f"/rooms/{room.id}"))
+
+app,rt,rooms,Room = fast_app('data/drawapp.db', render=render, id=int, name=str, created_at=str, canvas_data=str, pk='id')
+
+@rt("/")
+def get():
+    create_room = Form(Input(id="name", name="name", placeholder="New Room Name"),
+                       Button("Create Room"),
+                       hx_post="/rooms", hx_target="#rooms-list", hx_swap="afterbegin")
+    rooms_list = Ul(*rooms(order_by='id DESC'), id='rooms-list')
+    return Titled("QuickDraw", 
+                  create_room, rooms_list)
+
+@rt("/rooms")
+async def post(room:Room):
+    room.created_at = datetime.now().isoformat()
+    return rooms.insert(room)
+
+@rt("/rooms/{id}")
+async def get(id:int):
+    room = rooms[id]
+    canvas = Canvas(id="canvas", width="800", height="600")
+    color_picker = Input(type="color", id="color-picker", value="#000000")
+    brush_size = Input(type="range", id="brush-size", min="1", max="50", value="10")
+    save_button = Button("Save Canvas", id="save-canvas", hx_post=f"/rooms/{id}/save", hx_vals="js:{canvas_data: JSON.stringify(canvas.toJSON())}")
+
+    js = f"""
+    var canvas = new fabric.Canvas('canvas');
+    canvas.isDrawingMode = true;
+    canvas.freeDrawingBrush.color = '#000000';
+    canvas.freeDrawingBrush.width = 10;
+
+    // Load existing canvas data
+    fetch(`/rooms/{id}/load`)
+    .then(response => response.json())
+    .then(data => {{
+        if (data && Object.keys(data).length > 0) {{
+            canvas.loadFromJSON(data, canvas.renderAll.bind(canvas));
+        }}
+    }});
+    
+    document.getElementById('color-picker').onchange = function() {{
+        canvas.freeDrawingBrush.color = this.value;
+    }};
+    
+    document.getElementById('brush-size').oninput = function() {{
+        canvas.freeDrawingBrush.width = parseInt(this.value, 10);
+    }};
+    """
+    
+    return Titled(f"Room: {room.name}",
+                  A(Button("Leave Room"), href="/"),
+                  canvas,
+                  Div(color_picker, brush_size, save_button),
+                  Script(src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js"),
+                  Script(js))
+
+@rt("/rooms/{id}/save")
+async def post(id:int, canvas_data:str):
+    rooms.update({'canvas_data': canvas_data}, id)
+    return "Canvas saved successfully"
+
+@rt("/rooms/{id}/load")
+async def get(id:int):
+    room = rooms[id]
+    return room.canvas_data if room.canvas_data else "{}"
+
+serve()
+```
+
+</div>
+
+### Deploying to Railway
+
+You can deploy your website to a number of hosting providers, for this
+tutorial we’ll be using Railway. To get started, make sure you create an
+[account](https://railway.app/) and install the [Railway
+CLI](https://docs.railway.app/guides/cli). Once installed, make sure to
+run `railway login` to log in to your account.
+
+To make deploying your website as easy as possible, FastHTMl comes with
+a built in CLI tool that will handle most of the deployment process for
+you. To deploy your website, run the following command in your terminal
+in the root directory of your project:
+
+``` sh
+fh_railway_deploy quickdraw
+```
+
+<div>
+
+> **Note**
+>
+> Your app must be located in a `main.py` file for this to work.
+
+</div>
+
+### Conclusion: You’re a FastHTML Artist Now! 🎨🚀
+
+Congratulations! You’ve just built a sleek, interactive web application
+using FastHTML. Let’s recap what we’ve learned:
+
+1.  FastHTML allows you to create dynamic web apps with minimal code.
+2.  We used FastHTML’s routing system to handle different pages and
+    actions.
+3.  We integrated with a SQLite database to store room information and
+    canvas data.
+4.  We utilized Fabric.js to create an interactive drawing canvas.
+5.  We implemented features like color picking, brush size adjustment,
+    and canvas saving.
+6.  We used HTMX for seamless, partial page updates without full
+    reloads.
+7.  We learned how to deploy our FastHTML application to Railway for
+    easy hosting.
+
+You’ve taken your first steps into the world of FastHTML development.
+From here, the possibilities are endless! You could enhance the drawing
+app further by adding features like:
+
+- Implementing different drawing tools (e.g., shapes, text)
+- Adding user authentication
+- Creating a gallery of saved drawings
+- Implementing real-time collaborative drawing using WebSockets
+
+Whatever you choose to build next, FastHTML has got your back. Now go
+forth and create something awesome! Happy coding! 🖼️🚀</doc><doc title="FastHTML by Example" desc="A collection of 4 FastHTML apps showcasing idiomatic use of FastHTML and HTMX patterns."># FastHTML By Example
+
+
+
+This tutorial provides an alternate introduction to FastHTML by building
+out example applications. We also illustrate how to use FastHTML
+foundations to create custom web apps. Finally, this document serves as
+minimal context for a LLM to turn it into a FastHTML assistant.
+
+Let’s get started.
+
+## FastHTML Basics
+
+FastHTML is *just Python*. You can install it with
+`pip install python-fasthtml`. Extensions/components built for it can
+likewise be distributed via PyPI or as simple Python files.
+
+The core usage of FastHTML is to define routes, and then to define what
+to do at each route. This is similar to the
+[FastAPI](https://fastapi.tiangolo.com/) web framework (in fact we
+implemented much of the functionality to match the FastAPI usage
+examples), but where FastAPI focuses on returning JSON data to build
+APIs, FastHTML focuses on returning HTML data.
+
+Here’s a simple FastHTML app that returns a “Hello, World” message:
+
+``` python
+from fasthtml.common import FastHTML, serve
+
+app = FastHTML()
+
+@app.get("/")
+def home():
+    return "<h1>Hello, World</h1>"
+
+serve()
+```
+
+To run this app, place it in a file, say `app.py`, and then run it with
+`python app.py`.
+
+    INFO:     Will watch for changes in these directories: ['/home/jonathan/fasthtml-example']
+    INFO:     Uvicorn running on http://127.0.0.1:5001 (Press CTRL+C to quit)
+    INFO:     Started reloader process [871942] using WatchFiles
+    INFO:     Started server process [871945]
+    INFO:     Waiting for application startup.
+    INFO:     Application startup complete.
+
+If you navigate to <http://127.0.0.1:5001> in a browser, you’ll see your
+“Hello, World”. If you edit the `app.py` file and save it, the server
+will reload and you’ll see the updated message when you refresh the page
+in your browser.
+
+## Constructing HTML
+
+Notice we wrote some HTML in the previous example. We don’t want to do
+that! Some web frameworks require that you learn HTML, CSS, JavaScript
+AND some templating language AND python. We want to do as much as
+possible with just one language. Fortunately, the Python module
+[fastcore.xml](https://fastcore.fast.ai/xml.html) has all we need for
+constructing HTML from Python, and FastHTML includes all the tags you
+need to get started. For example:
+
+``` python
+from fasthtml.common import *
+page = Html(
+    Head(Title('Some page')),
+    Body(Div('Some text, ', A('A link', href='https://example.com'), Img(src="https://placehold.co/200"), cls='myclass')))
+print(to_xml(page))
+```
+
+    <!doctype html></!doctype>
+
+    <html>
+      <head>
+        <title>Some page</title>
+      </head>
+      <body>
+        <div class="myclass">
+    Some text, 
+          <a href="https://example.com">A link</a>
+          <img src="https://placehold.co/200">
+        </div>
+      </body>
+    </html>
+
+``` python
+show(page)
+```
+
+<!doctype html></!doctype>
+&#10;<html>
+  <head>
+    <title>Some page</title>
+  </head>
+  <body>
+    <div class="myclass">
+Some text, 
+      <a href="https://example.com">A link</a>
+      <img src="https://placehold.co/200">
+    </div>
+  </body>
+</html>
+
+If that `import *` worries you, you can always import only the tags you
+need.
+
+FastHTML is smart enough to know about fastcore.xml, and so you don’t
+need to use the `to_xml` function to convert your FT objects to HTML.
+You can just return them as you would any other Python object. For
+example, if we modify our previous example to use fastcore.xml, we can
+return an FT object directly:
+
+``` python
+from fasthtml.common import *
+app = FastHTML()
+
+@app.get("/")
+def home():
+    page = Html(
+        Head(Title('Some page')),
+        Body(Div('Some text, ', A('A link', href='https://example.com'), Img(src="https://placehold.co/200"), cls='myclass')))
+    return page
+
+serve()
+```
+
+This will render the HTML in the browser.
+
+For debugging, you can right-click on the rendered HTML in the browser
+and select “Inspect” to see the underlying HTML that was generated.
+There you’ll also find the ‘network’ tab, which shows you the requests
+that were made to render the page. Refresh and look for the request to
+`127.0.0.1` - and you’ll see it’s just a `GET` request to `/`, and the
+response body is the HTML you just returned.
+
+<div>
+
+> **Live Reloading**
+>
+> You can also enable [live reloading](../ref/live_reload.ipynb) so you
+> don’t have to manually refresh your browser to view updates.
+
+</div>
+
+You can also use Starlette’s `TestClient` to try it out in a notebook:
+
+``` python
+from starlette.testclient import TestClient
+client = TestClient(app)
+r = client.get("/")
+print(r.text)
+```
+
+    <html>
+      <head><title>Some page</title>
+    </head>
+      <body><div class="myclass">
+    Some text, 
+      <a href="https://example.com">A link</a>
+      <img src="https://placehold.co/200">
+    </div>
+    </body>
+    </html>
+
+FastHTML wraps things in an Html tag if you don’t do it yourself (unless
+the request comes from htmx, in which case you get the element
+directly). See [FT objects and HTML](#ft-objects-and-html) for more on
+creating custom components or adding HTML rendering to existing Python
+objects. To give the page a non-default title, return a Title before
+your main content:
+
+``` python
+app = FastHTML()
+
+@app.get("/")
+def home():
+    return Title("Page Demo"), Div(H1('Hello, World'), P('Some text'), P('Some more text'))
+
+client = TestClient(app)
+print(client.get("/").text)
+```
+
+    <!doctype html></!doctype>
+
+    <html>
+      <head>
+        <title>Page Demo</title>
+        <meta charset="utf-8"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"></meta>
+        <script src="https://unpkg.com/htmx.org@next/dist/htmx.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/answerdotai/surreal@1.3.0/surreal.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js"></script>
+      </head>
+      <body>
+    <div>
+      <h1>Hello, World</h1>
+      <p>Some text</p>
+      <p>Some more text</p>
+    </div>
+      </body>
+    </html>
+
+We’ll use this pattern often in the examples to follow.
+
+## Defining Routes
+
+The HTTP protocol defines a number of methods (‘verbs’) to send requests
+to a server. The most common are GET, POST, PUT, DELETE, and HEAD. We
+saw ‘GET’ in action before - when you navigate to a URL, you’re making a
+GET request to that URL. We can do different things on a route for
+different HTTP methods. For example:
+
+``` python
+@app.route("/", methods='get')
+def home():
+    return H1('Hello, World')
+
+@app.route("/", methods=['post', 'put'])
+def post_or_put():
+    return "got a POST or PUT request"
+```
+
+This says that when someone navigates to the root URL “/” (i.e. sends a
+GET request), they will see the big “Hello, World” heading. When someone
+submits a POST or PUT request to the same URL, the server should return
+the string “got a post or put request”.
+
+<div>
+
+> **Test the POST request**
+>
+> You can test the POST request with
+> `curl -X POST http://127.0.0.1:8000 -d "some data"`. This sends some
+> data to the server, you should see the response “got a post or put
+> request” printed in the terminal.
+
+</div>
+
+There are a few other ways you can specify the route+method - FastHTML
+has `.get`, `.post`, etc. as shorthand for
+`route(..., methods=['get'])`, etc.
+
+``` python
+@app.get("/")
+def my_function():
+    return "Hello World from a GET request"
+```
+
+Or you can use the `@rt` decorator without a method but specify the
+method with the name of the function. For example:
+
+``` python
+rt = app.route
+
+@rt("/")
+def post():
+    return "Hello World from a POST request"
+```
+
+``` python
+client.post("/").text
+```
+
+    'Hello World from a POST request'
+
+You’re welcome to pick whichever style you prefer. Using routes lets you
+show different content on different pages - ‘/home’, ‘/about’ and so on.
+You can also respond differently to different kinds of requests to the
+same route, as shown above. You can also pass data via the route:
+
+<div class="panel-tabset">
+
+## `@app.get`
+
+``` python
+@app.get("/greet/{nm}")
+def greet(nm:str):
+    return f"Good day to you, {nm}!"
+
+client.get("/greet/Dave").text
+```
+
+    'Good day to you, Dave!'
+
+## `@rt`
+
+``` python
+@rt("/greet/{nm}")
+def get(nm:str):
+    return f"Good day to you, {nm}!"
+
+client.get("/greet/Dave").text
+```
+
+    'Good day to you, Dave!'
+
+</div>
+
+More on this in the [More on Routing and Request
+Parameters](#more-on-routing-and-request-parameters) section, which goes
+deeper into the different ways to get information from a request.
+
+## Styling Basics
+
+Plain HTML probably isn’t quite what you imagine when you visualize your
+beautiful web app. CSS is the go-to language for styling HTML. But
+again, we don’t want to learn extra languages unless we absolutely have
+to! Fortunately, there are ways to get much more visually appealing
+sites by relying on the hard work of others, using existing CSS
+libraries. One of our favourites is [PicoCSS](https://picocss.com/). A
+common way to add CSS files to web pages is to use a
+[`<link>`](https://www.w3schools.com/tags/tag_link.asp) tag inside your
+[HTML header](https://www.w3schools.com/tags/tag_header.asp), like this:
+
+``` html
+<header>
+    ...
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css">
+</header>
+```
+
+For convenience, FastHTML already defines a Pico component for you with
+`picolink`:
+
+``` python
+print(to_xml(picolink))
+```
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css">
+
+    <style>:root { --pico-font-size: 100%; }</style>
+
+<div>
+
+> **Note**
+>
+> `picolink` also includes a `<style>` tag, as we found that setting the
+> font-size to 100% to be a good default. We show you how to override
+> this below.
+
+</div>
+
+Since we typically want CSS styling on all pages of our app, FastHTML
+lets you define a shared HTML header with the `hdrs` argument as shown
+below:
+
+``` python
+from fasthtml.common import *
+css = Style(':root {--pico-font-size:90%,--pico-font-family: Pacifico, cursive;}')
+app = FastHTML(hdrs=(picolink, css))
+
+@app.route("/")
+def get():
+    return (Title("Hello World"), 
+            Main(H1('Hello, World'), cls="container"))
+```
+
+Line 2  
+Custom styling to override the pico defaults
+
+Line 3  
+Define shared headers for all pages
+
+Line 8  
+As per the [pico docs](https://picocss.com/docs), we put all of our
+content inside a `<main>` tag with a class of `container`:
+
+<div>
+
+> **Returning Tuples**
+>
+> We’re returning a tuple here (a title and the main page). Returning a
+> tuple, list, `FT` object, or an object with a `__ft__` method tells
+> FastHTML to turn the main body into a full HTML page that includes the
+> headers (including the pico link and our custom css) which we passed
+> in. This only occurs if the request isn’t from HTMX (for HTMX requests
+> we need only return the rendered components).
+
+</div>
+
+You can check out the Pico [examples](https://picocss.com/examples) page
+to see how different elements will look. If everything is working, the
+page should now render nice text with our custom font, and it should
+respect the user’s light/dark mode preferences too.
+
+If you want to [override the default
+styles](https://picocss.com/docs/css-variables) or add more custom CSS,
+you can do so by adding a `<style>` tag to the headers as shown above.
+So you are allowed to write CSS to your heart’s content - we just want
+to make sure you don’t necessarily have to! Later on we’ll see examples
+using other component libraries and tailwind css to do more fancy
+styling things, along with tips to get an LLM to write all those fiddly
+bits so you don’t have to.
+
+## Web Page -\> Web App
+
+Showing content is all well and good, but we typically expect a bit more
+*interactivity* from something calling itself a web app! So, let’s add a
+few different pages, and use a form to let users add messages to a list:
+
+``` python
+app = FastHTML()
+messages = ["This is a message, which will get rendered as a paragraph"]
+
+@app.get("/")
+def home():
+    return Main(H1('Messages'), 
+                *[P(msg) for msg in messages],
+                A("Link to Page 2 (to add messages)", href="/page2"))
+
+@app.get("/page2")
+def page2():
+    return Main(P("Add a message with the form below:"),
+                Form(Input(type="text", name="data"),
+                     Button("Submit"),
+                     action="/", method="post"))
+
+@app.post("/")
+def add_message(data:str):
+    messages.append(data)
+    return home()
+```
+
+We re-render the entire homepage to show the newly added message. This
+is fine, but modern web apps often don’t re-render the entire page, they
+just update a part of the page. In fact even very complicated
+applications are often implemented as ‘Single Page Apps’ (SPAs). This is
+where HTMX comes in.
+
+## HTMX
+
+[HTMX](https://htmx.org/) addresses some key limitations of HTML. In
+vanilla HTML, links can trigger a GET request to show a new page, and
+forms can send requests containing data to the server. A lot of ‘Web
+1.0’ design revolved around ways to use these to do everything we
+wanted. But why should only *some* elements be allowed to trigger
+requests? And why should we refresh the *entire page* with the result
+each time one does? HTMX extends HTML to allow us to trigger requests
+from *any* element on all kinds of events, and to update a part of the
+page without refreshing the entire page. It’s a powerful tool for
+building modern web apps.
+
+It does this by adding attributes to HTML tags to make them do things.
+For example, here’s a page with a counter and a button that increments
+it:
+
+``` python
+app = FastHTML()
+
+count = 0
+
+@app.get("/")
+def home():
+    return Title("Count Demo"), Main(
+        H1("Count Demo"),
+        P(f"Count is set to {count}", id="count"),
+        Button("Increment", hx_post="/increment", hx_target="#count", hx_swap="innerHTML")
+    )
+
+@app.post("/increment")
+def increment():
+    print("incrementing")
+    global count
+    count += 1
+    return f"Count is set to {count}"
+```
+
+The button triggers a POST request to `/increment` (since we set
+`hx_post="/increment"`), which increments the count and returns the new
+count. The `hx_target` attribute tells HTMX where to put the result. If
+no target is specified it replaces the element that triggered the
+request. The `hx_swap` attribute specifies how it adds the result to the
+page. Useful options are:
+
+- *`innerHTML`*: Replace the target element’s content with the result.
+- *`outerHTML`*: Replace the target element with the result.
+- *`beforebegin`*: Insert the result before the target element.
+- *`beforeend`*: Insert the result inside the target element, after its
+  last child.
+- *`afterbegin`*: Insert the result inside the target element, before
+  its first child.
+- *`afterend`*: Insert the result after the target element.
+
+You can also use an hx_swap of `delete` to delete the target element
+regardless of response, or of `none` to do nothing.
+
+By default, requests are triggered by the “natural” event of an
+element - click in the case of a button (and most other elements). You
+can also specify different triggers, along with various modifiers - see
+the [HTMX docs](https://htmx.org/docs/#triggers) for more.
+
+This pattern of having elements trigger requests that modify or replace
+other elements is a key part of the HTMX philosophy. It takes a little
+getting used to, but once mastered it is extremely powerful.
+
+### Replacing Elements Besides the Target
+
+Sometimes having a single target is not enough, and we’d like to specify
+some additional elements to update or remove. In these cases, returning
+elements with an id that matches the element to be replaced and
+`hx_swap_oob='true'` will replace those elements too. We’ll use this in
+the next example to clear an input field when we submit a form.
+
+## Full Example \#1 - ToDo App
+
+The canonical demo web app! A TODO list. Rather than create yet another
+variant for this tutorial, we recommend starting with this video
+tutorial from Jeremy:
+
+<https://www.youtube.com/embed/Auqrm7WFc0I>
+
+<figure>
+<img src="by_example_files/figure-commonmark/cell-53-1-image.png"
+alt="image.png" />
+<figcaption aria-hidden="true">image.png</figcaption>
+</figure>
+
+We’ve made a number of variants of this app - so in addition to the
+version shown in the video you can browse
+[this](https://github.com/AnswerDotAI/fasthtml-tut) series of examples
+with increasing complexity, the heavily-commented [“idiomatic” version
+here](https://github.com/AnswerDotAI/fasthtml/blob/main/examples/adv_app.py),
+and the
+[example](https://github.com/AnswerDotAI/fasthtml-example/tree/main/01_todo_app)
+linked from the [FastHTML homepage](https://fastht.ml/).
+
+## Full Example \#2 - Image Generation App
+
+Let’s create an image generation app. We’d like to wrap a text-to-image
+model in a nice UI, where the user can type in a prompt and see a
+generated image appear. We’ll use a model hosted by
+[Replicate](https://replicate.com) to actually generate the images.
+Let’s start with the homepage, with a form to submit prompts and a div
+to hold the generated images:
+
+``` python
+# Main page
+@app.get("/")
+def get():
+    inp = Input(id="new-prompt", name="prompt", placeholder="Enter a prompt")
+    add = Form(Group(inp, Button("Generate")), hx_post="/", target_id='gen-list', hx_swap="afterbegin")
+    gen_list = Div(id='gen-list')
+    return Title('Image Generation Demo'), Main(H1('Magic Image Generation'), add, gen_list, cls='container')
+```
+
+Submitting the form will trigger a POST request to `/`, so next we need
+to generate an image and add it to the list. One problem: generating
+images is slow! We’ll start the generation in a separate thread, but
+this now surfaces a different problem: we want to update the UI right
+away, but our image will only be ready a few seconds later. This is a
+common pattern - think about how often you see a loading spinner online.
+We need a way to return a temporary bit of UI which will eventually be
+replaced by the final image. Here’s how we might do this:
+
+``` python
+def generation_preview(id):
+    if os.path.exists(f"gens/{id}.png"):
+        return Div(Img(src=f"/gens/{id}.png"), id=f'gen-{id}')
+    else:
+        return Div("Generating...", id=f'gen-{id}', 
+                   hx_post=f"/generations/{id}",
+                   hx_trigger='every 1s', hx_swap='outerHTML')
+    
+@app.post("/generations/{id}")
+def get(id:int): return generation_preview(id)
+
+@app.post("/")
+def post(prompt:str):
+    id = len(generations)
+    generate_and_save(prompt, id)
+    generations.append(prompt)
+    clear_input =  Input(id="new-prompt", name="prompt", placeholder="Enter a prompt", hx_swap_oob='true')
+    return generation_preview(id), clear_input
+
+@threaded
+def generate_and_save(prompt, id): ... 
+```
+
+The form sends the prompt to the `/` route, which starts the generation
+in a separate thread then returns two things:
+
+- A generation preview element that will be added to the top of the
+  `gen-list` div (since that is the target_id of the form which
+  triggered the request)
+- An input field that will replace the form’s input field (that has the
+  same id), using the hx_swap_oob=‘true’ trick. This clears the prompt
+  field so the user can type another prompt.
+
+The generation preview first returns a temporary “Generating…” message,
+which polls the `/generations/{id}` route every second. This is done by
+setting hx_post to the route and hx_trigger to ‘every 1s’. The
+`/generations/{id}` route returns the preview element every second until
+the image is ready, at which point it returns the final image. Since the
+final image replaces the temporary one (hx_swap=‘outerHTML’), the
+polling stops running and the generation preview is now complete.
+
+This works nicely - the user can submit several prompts without having
+to wait for the first one to generate, and as the images become
+available they are added to the list. You can see the full code of this
+version
+[here](https://github.com/AnswerDotAI/fasthtml-example/blob/main/image_app_simple/draft1.py).
+
+### Again, with Style
+
+The app is functional, but can be improved. The [next
+version](https://github.com/AnswerDotAI/fasthtml-example/blob/main/image_app_simple/main.py)
+adds more stylish generation previews, lays out the images in a grid
+layout that is responsive to different screen sizes, and adds a database
+to track generations and make them persistent. The database part is very
+similar to the todo list example, so let’s just quickly look at how we
+add the nice grid layout. This is what the result looks like:
+
+<figure>
+<img src="by_example_files/figure-commonmark/cell-58-1-image.png"
+alt="image.png" />
+<figcaption aria-hidden="true">image.png</figcaption>
+</figure>
+
+Step one was looking around for existing components. The Pico CSS
+library we’ve been using has a rudimentary grid but recommends using an
+alternative layout system. One of the options listed was
+[Flexbox](http://flexboxgrid.com/).
+
+To use Flexbox you create a “row” with one or more elements. You can
+specify how wide things should be with a specific syntax in the class
+name. For example, `col-xs-12` means a box that will take up 12 columns
+(out of 12 total) of the row on extra small screens, `col-sm-6` means a
+column that will take up 6 columns of the row on small screens, and so
+on. So if you want four columns on large screens you would use
+`col-lg-3` for each item (i.e. each item is using 3 columns out of 12).
+
+``` html
+<div class="row">
+    <div class="col-xs-12">
+        <div class="box">This takes up the full width</div>
+    </div>
+</div>
+```
+
+This was non-intuitive to me. Thankfully ChatGPT et al know web stuff
+quite well, and we can also experiment in a notebook to test things out:
+
+``` python
+grid = Html(
+    Link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/flexboxgrid/6.3.1/flexboxgrid.min.css", type="text/css"),
+    Div(
+        Div(Div("This takes up the full width", cls="box", style="background-color: #800000;"), cls="col-xs-12"),
+        Div(Div("This takes up half", cls="box", style="background-color: #008000;"), cls="col-xs-6"),
+        Div(Div("This takes up half", cls="box", style="background-color: #0000B0;"), cls="col-xs-6"),
+        cls="row", style="color: #fff;"
+    )
+)
+show(grid)
+```
+
+<!doctype html></!doctype>
+&#10;<html>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flexboxgrid/6.3.1/flexboxgrid.min.css" type="text/css">
+  <div class="row" style="color: #fff;">
+    <div class="col-xs-12">
+      <div class="box" style="background-color: #800000;">This takes up the full width</div>
+    </div>
+    <div class="col-xs-6">
+      <div class="box" style="background-color: #008000;">This takes up half</div>
+    </div>
+    <div class="col-xs-6">
+      <div class="box" style="background-color: #0000B0;">This takes up half</div>
+    </div>
+  </div>
+</html>
+
+Aside: when in doubt with CSS stuff, add a background color or a border
+so you can see what’s happening!
+
+Translating this into our app, we have a new homepage with a
+`div (class="row")` to store the generated images / previews, and a
+`generation_preview` function that returns boxes with the appropriate
+classes and styles to make them appear in the grid. I chose a layout
+with different numbers of columns for different screen sizes, but you
+could also *just* specify the `col-xs` class if you wanted the same
+layout on all devices.
+
+``` python
+gridlink = Link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/flexboxgrid/6.3.1/flexboxgrid.min.css", type="text/css")
+app = FastHTML(hdrs=(picolink, gridlink))
+
+# Main page
+@app.get("/")
+def get():
+    inp = Input(id="new-prompt", name="prompt", placeholder="Enter a prompt")
+    add = Form(Group(inp, Button("Generate")), hx_post="/", target_id='gen-list', hx_swap="afterbegin")
+    gen_containers = [generation_preview(g) for g in gens(limit=10)] # Start with last 10
+    gen_list = Div(*gen_containers[::-1], id='gen-list', cls="row") # flexbox container: class = row
+    return Title('Image Generation Demo'), Main(H1('Magic Image Generation'), add, gen_list, cls='container')
+
+# Show the image (if available) and prompt for a generation
+def generation_preview(g):
+    grid_cls = "box col-xs-12 col-sm-6 col-md-4 col-lg-3"
+    image_path = f"{g.folder}/{g.id}.png"
+    if os.path.exists(image_path):
+        return Div(Card(
+                       Img(src=image_path, alt="Card image", cls="card-img-top"),
+                       Div(P(B("Prompt: "), g.prompt, cls="card-text"),cls="card-body"),
+                   ), id=f'gen-{g.id}', cls=grid_cls)
+    return Div(f"Generating gen {g.id} with prompt {g.prompt}", 
+            id=f'gen-{g.id}', hx_get=f"/gens/{g.id}", 
+            hx_trigger="every 2s", hx_swap="outerHTML", cls=grid_cls)
+```
+
+You can see the final result in
+[main.py](https://github.com/AnswerDotAI/fasthtml-example/blob/main/image_app_simple/main.py)
+in the `image_app_simple` example directory, along with info on
+deploying it (tl;dr don’t!). We’ve also deployed a version that only
+shows *your* generations (tied to browser session) and has a credit
+system to save our bank accounts. You can access that
+[here](https://image-gen-public-credit-pool.replit.app/). Now for the
+next question: how do we keep track of different users?
+
+### Again, with Sessions
+
+At the moment everyone sees all images! How do we keep some sort of
+unique identifier tied to a user? Before going all the way to setting up
+users, login pages etc., let’s look at a way to at least limit
+generations to the user’s *session*. You could do this manually with
+cookies. For convenience and security, fasthtml (via Starlette) has a
+special mechanism for storing small amounts of data in the user’s
+browser via the `session` argument to your route. This acts like a
+dictionary and you can set and get values from it. For example, here we
+look for a `session_id` key, and if it doesn’t exist we generate a new
+one:
+
+``` python
+@app.get("/")
+def get(session):
+    if 'session_id' not in session: session['session_id'] = str(uuid.uuid4())
+    return H1(f"Session ID: {session['session_id']}")
+```
+
+Refresh the page a few times - you’ll notice that the session ID remains
+the same. If you clear your browsing data, you’ll get a new session ID.
+And if you load the page in a different browser (but not a different
+tab), you’ll get a new session ID. This will persist within the current
+browser, letting us use it as a key for our generations. As a bonus,
+someone can’t spoof this session id by passing it in another way (for
+example, sending a query parameter). Behind the scenes, the data *is*
+stored in a browser cookie but it is signed with a secret key that stops
+the user or anyone nefarious from being able to tamper with it. The
+cookie is decoded back into a dictionary by something called a
+middleware function, which we won’t cover here. All you need to know is
+that we can use this to store bits of state in the user’s browser.
+
+In the image app example, we can add a `session_id` column to our
+database, and modify our homepage like so:
+
+``` python
+@app.get("/")
+def get(session):
+    if 'session_id' not in session: session['session_id'] = str(uuid.uuid4())
+    inp = Input(id="new-prompt", name="prompt", placeholder="Enter a prompt")
+    add = Form(Group(inp, Button("Generate")), hx_post="/", target_id='gen-list', hx_swap="afterbegin")
+    gen_containers = [generation_preview(g) for g in gens(limit=10, where=f"session_id == '{session['session_id']}'")]
+    ...
+```
+
+So we check if the session id exists in the session, add one if not, and
+then limit the generations shown to only those tied to this session id.
+We filter the database with a where clause - see \[TODO link Jeremy’s
+example for a more reliable way to do this\]. The only other change we
+need to make is to store the session id in the database when a
+generation is made. You can check out this version
+[here](https://github.com/AnswerDotAI/fasthtml-example/blob/main/image_app_session_credits/session.py).
+You could instead write this app without relying on a database at all -
+simply storing the filenames of the generated images in the session, for
+example. But this more general approach of linking some kind of unique
+session identifier to users or data in our tables is a useful general
+pattern for more complex examples.
+
+### Again, with Credits!
+
+Generating images with replicate costs money. So next let’s add a pool
+of credits that get used up whenever anyone generates an image. To
+recover our lost funds, we’ll also set up a payment system so that
+generous users can buy more credits for everyone. You could modify this
+to let users buy credits tied to their session ID, but at that point you
+risk having angry customers losing their money after wiping their
+browser history, and should consider setting up proper account
+management :)
+
+Taking payments with Stripe is intimidating but very doable. [Here’s a
+tutorial](https://testdriven.io/blog/flask-stripe-tutorial/) that shows
+the general principle using Flask. As with other popular tasks in the
+web-dev world, ChatGPT knows a lot about Stripe - but you should
+exercise extra caution when writing code that handles money!
+
+For the [finished
+example](https://github.com/AnswerDotAI/fasthtml-example/blob/main/image_app_session_credits/main.py)
+we add the bare minimum:
+
+- A way to create a Stripe checkout session and redirect the user to the
+  session URL
+- ‘Success’ and ‘Cancel’ routes to handle the result of the checkout
+- A route that listens for a webhook from Stripe to update the number of
+  credits when a payment is made.
+
+In a typical application you’ll want to keep track of which users make
+payments, catch other kinds of stripe events and so on. This example is
+more a ‘this is possible, do your own research’ than ‘this is how you do
+it’. But hopefully it does illustrate the key idea: there is no magic
+here. Stripe (and many other technologies) relies on sending users to
+different routes and shuttling data back and forth in requests. And we
+know how to do that!
+
+## More on Routing and Request Parameters
+
+There are a number of ways information can be passed to the server. When
+you specify arguments to a route, FastHTML will search the request for
+values with the same name, and convert them to the correct type. In
+order, it searches
+
+- The path parameters
+- The query parameters
+- The cookies
+- The headers
+- The session
+- Form data
+
+There are also a few special arguments
+
+- `request` (or any prefix like `req`): gets the raw Starlette `Request`
+  object
+- `session` (or any prefix like `sess`): gets the session object
+- `auth`
+- `htmx`
+- `app`
+
+In this section let’s quickly look at some of these in action.
+
+``` python
+from fasthtml.common import *
+from starlette.testclient import TestClient
+
+app = FastHTML()
+cli = TestClient(app)
+```
+
+Part of the route (path parameters):
+
+``` python
+@app.get('/user/{nm}')
+def _(nm:str): return f"Good day to you, {nm}!"
+
+cli.get('/user/jph').text
+```
+
+    'Good day to you, jph!'
+
+Matching with a regex:
+
+``` python
+reg_re_param("imgext", "ico|gif|jpg|jpeg|webm")
+
+@app.get(r'/static/{path:path}/{fn}.{ext:imgext}')
+def get_img(fn:str, path:str, ext:str): return f"Getting {fn}.{ext} from /{path}"
+
+cli.get('/static/foo/jph.ico').text
+```
+
+    'Getting jph.ico from /foo/'
+
+Using an enum (try using a string that isn’t in the enum):
+
+``` python
+ModelName = str_enum('ModelName', "alexnet", "resnet", "lenet")
+
+@app.get("/models/{nm}")
+def model(nm:ModelName): return nm
+
+print(cli.get('/models/alexnet').text)
+```
+
+    alexnet
+
+Casting to a Path:
+
+``` python
+@app.get("/files/{path}")
+def txt(path: Path): return path.with_suffix('.txt')
+
+print(cli.get('/files/foo').text)
+```
+
+    foo.txt
+
+An integer with a default value:
+
+``` python
+fake_db = [{"name": "Foo"}, {"name": "Bar"}]
+
+@app.get("/items/")
+def read_item(idx: int = 0): return fake_db[idx]
+
+print(cli.get('/items/?idx=1').text)
+```
+
+    {"name":"Bar"}
+
+``` python
+# Equivalent to `/items/?idx=0`.
+print(cli.get('/items/').text)
+```
+
+    {"name":"Foo"}
+
+Boolean values (takes anything “truthy” or “falsy”):
+
+``` python
+@app.get("/booly/")
+def booly(coming:bool=True): return 'Coming' if coming else 'Not coming'
+
+print(cli.get('/booly/?coming=true').text)
+```
+
+    Coming
+
+``` python
+print(cli.get('/booly/?coming=no').text)
+```
+
+    Not coming
+
+Getting dates:
+
+``` python
+@app.get("/datie/")
+def datie(d:parsed_date): return d
+
+date_str = "17th of May, 2024, 2p"
+print(cli.get(f'/datie/?d={date_str}').text)
+```
+
+    2024-05-17 14:00:00
+
+Matching a dataclass:
+
+``` python
+from dataclasses import dataclass, asdict
+
+@dataclass
+class Bodie:
+    a:int;b:str
+
+@app.route("/bodie/{nm}")
+def post(nm:str, data:Bodie):
+    res = asdict(data)
+    res['nm'] = nm
+    return res
+
+cli.post('/bodie/me', data=dict(a=1, b='foo')).text
+```
+
+    '{"a":1,"b":"foo","nm":"me"}'
+
+### Cookies
+
+Cookies can be set via a Starlette Response object, and can be read back
+by specifying the name:
+
+``` python
+from datetime import datetime
+
+@app.get("/setcookie")
+def setc(req):
+    now = datetime.now()
+    res = Response(f'Set to {now}')
+    res.set_cookie('now', str(now))
+    return res
+
+cli.get('/setcookie').text
+```
+
+    'Set to 2024-07-20 23:14:54.364793'
+
+``` python
+@app.get("/getcookie")
+def getc(now:parsed_date): return f'Cookie was set at time {now.time()}'
+
+cli.get('/getcookie').text
+```
+
+    'Cookie was set at time 23:14:54.364793'
+
+### User Agent and HX-Request
+
+An argument of `user_agent` will match the header `User-Agent`. This
+holds for special headers like `HX-Request` (used by HTMX to signal when
+a request comes from an HTMX request) - the general pattern is that “-”
+is replaced with “\_” and strings are turned to lowercase.
+
+``` python
+@app.get("/ua")
+async def ua(user_agent:str): return user_agent
+
+cli.get('/ua', headers={'User-Agent':'FastHTML'}).text
+```
+
+    'FastHTML'
+
+``` python
+@app.get("/hxtest")
+def hxtest(htmx): return htmx.request
+
+cli.get('/hxtest', headers={'HX-Request':'1'}).text
+```
+
+    '1'
+
+### Starlette Requests
+
+If you add an argument called `request`(or any prefix of that, for
+example `req`) it will be populated with the Starlette `Request` object.
+This is useful if you want to do your own processing manually. For
+example, although FastHTML will parse forms for you, you could instead
+get form data like so:
+
+``` python
+@app.get("/form")
+async def form(request:Request):
+    form_data = await request.form()
+    a = form_data.get('a')
+```
+
+See the [Starlette docs](https://starlette.io/docs/) for more
+information on the `Request` object.
+
+### Starlette Responses
+
+You can return a Starlette Response object from a route to control the
+response. For example:
+
+``` python
+@app.get("/redirect")
+def redirect():
+    return RedirectResponse(url="/")
+```
+
+We used this to set cookies in the previous example. See the [Starlette
+docs](https://starlette.io/docs/) for more information on the `Response`
+object.
+
+### Static Files
+
+We often want to serve static files like images. This is easily done!
+For common file types (images, CSS etc) we can create a route that
+returns a Starlette `FileResponse` like so:
+
+``` python
+# For images, CSS, etc.
+@app.get("/{fname:path}.{ext:static}")
+def static(fname: str, ext: str):
+  return FileResponse(f'{fname}.{ext}')
+```
+
+You can customize it to suit your needs (for example, only serving files
+in a certain directory). You’ll notice some variant of this route in all
+our complete examples - even for apps with no static files the browser
+will typically request a `/favicon.ico` file, for example, and as the
+astute among you will have noticed this has sparked a bit of competition
+between Johno and Jeremy regarding which country flag should serve as
+the default!
+
+### WebSockets
+
+For certain applications such as multiplayer games, websockets can be a
+powerful feature. Luckily HTMX and FastHTML has you covered! Simply
+specify that you wish to include the websocket header extension from
+HTMX:
+
+``` python
+app = FastHTML(exts='ws')
+rt = app.route
+```
+
+With that, you are now able to specify the different websocket specific
+HTMX goodies. For example, say we have a website we want to setup a
+websocket, you can simply:
+
+``` python
+def mk_inp(): return Input(id='msg')
+
+@rt('/')
+async def get(request):
+    cts = Div(
+        Div(id='notifications'),
+        Form(mk_inp(), id='form', ws_send=True),
+        hx_ext='ws', ws_connect='/ws')
+    return Titled('Websocket Test', cts)
+```
+
+And this will setup a connection on the route `/ws` along with a form
+that will send a message to the websocket whenever the form is
+submitted. Let’s go ahead and handle this route:
+
+``` python
+@app.ws('/ws')
+async def ws(msg:str, send):
+    await send(Div('Hello ' + msg, id="notifications"))
+    await sleep(2)
+    return Div('Goodbye ' + msg, id="notifications"), mk_inp()
+```
+
+One thing you might have noticed is a lack of target id for our
+websocket trigger for swapping HTML content. This is because HTMX always
+swaps content with websockets with Out of Band Swaps. Therefore, HTMX
+will look for the id in the returned HTML content from the server for
+determining what to swap. To send stuff to the client, you can either
+use the `send` parameter or simply return the content or both!
+
+Now, sometimes you might want to perform actions when a client connects
+or disconnects such as add or remove a user from a player queue. To hook
+into these events, you can pass your connection or disconnection
+function to the `app.ws` decorator:
+
+``` python
+async def on_connect(send):
+    print('Connected!')
+    await send(Div('Hello, you have connected', id="notifications"))
+
+async def on_disconnect(ws):
+    print('Disconnected!')
+
+@app.ws('/ws', conn=on_connect, disconn=on_disconnect)
+async def ws(msg:str, send):
+    await send(Div('Hello ' + msg, id="notifications"))
+    await sleep(2)
+    return Div('Goodbye ' + msg, id="notifications"), mk_inp()
+```
+
+## Full Example \#3 - Chatbot Example with DaisyUI Components
+
+Let’s go back to the topic of adding components or styling beyond the
+simple PicoCSS examples so far. How might we adopt a component or
+framework? In this example, let’s build a chatbot UI leveraging the
+[DaisyUI chat bubble](https://daisyui.com/components/chat/). The final
+result will look like this:
+
+<figure>
+<img src="by_example_files/figure-commonmark/cell-101-1-image.png"
+alt="image.png" />
+<figcaption aria-hidden="true">image.png</figcaption>
+</figure>
+
+At first glance, DaisyUI’s chat component looks quite intimidating. The
+examples look like this:
+
+``` html
+<div class="chat chat-start">
+  <div class="chat-image avatar">
+    <div class="w-10 rounded-full">
+      <img alt="Tailwind CSS chat bubble component" src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg" />
+    </div>
+  </div>
+  <div class="chat-header">
+    Obi-Wan Kenobi
+    <time class="text-xs opacity-50">12:45</time>
+  </div>
+  <div class="chat-bubble">You were the Chosen One!</div>
+  <div class="chat-footer opacity-50">
+    Delivered
+  </div>
+</div>
+<div class="chat chat-end">
+  <div class="chat-image avatar">
+    <div class="w-10 rounded-full">
+      <img alt="Tailwind CSS chat bubble component" src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg" />
+    </div>
+  </div>
+  <div class="chat-header">
+    Anakin
+    <time class="text-xs opacity-50">12:46</time>
+  </div>
+  <div class="chat-bubble">I hate you!</div>
+  <div class="chat-footer opacity-50">
+    Seen at 12:46
+  </div>
+</div>
+```
+
+We have several things going for us however.
+
+- ChatGPT knows DaisyUI and Tailwind (DaisyUI is a Tailwind component
+  library)
+- We can build things up piece by piece with AI standing by to help.
+
+<https://h2f.answer.ai/> is a tool that can convert HTML to FT
+(fastcore.xml) and back, which is useful for getting a quick starting
+point when you have an HTML example to start from.
+
+We can strip out some unnecessary bits and try to get the simplest
+possible example working in a notebook first:
+
+``` python
+# Loading tailwind and daisyui
+headers = (Script(src="https://cdn.tailwindcss.com"),
+           Link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/daisyui@4.11.1/dist/full.min.css"))
+
+# Displaying a single message
+d = Div(
+    Div("Chat header here", cls="chat-header"),
+    Div("My message goes here", cls="chat-bubble chat-bubble-primary"),
+    cls="chat chat-start"
+)
+# show(Html(*headers, d)) # uncomment to view
+```
+
+Now we can extend this to render multiple messages, with the message
+being on the left (`chat-start`) or right (`chat-end`) depending on the
+role. While we’re at it, we can also change the color
+(`chat-bubble-primary`) of the message and put them all in a `chat-box`
+div:
+
+``` python
+messages = [
+    {"role":"user", "content":"Hello"},
+    {"role":"assistant", "content":"Hi, how can I assist you?"}
+]
+
+def ChatMessage(msg):
+    return Div(
+        Div(msg['role'], cls="chat-header"),
+        Div(msg['content'], cls=f"chat-bubble chat-bubble-{'primary' if msg['role'] == 'user' else 'secondary'}"),
+        cls=f"chat chat-{'end' if msg['role'] == 'user' else 'start'}")
+
+chatbox = Div(*[ChatMessage(msg) for msg in messages], cls="chat-box", id="chatlist")
+
+# show(Html(*headers, chatbox)) # Uncomment to view
+```
+
+Next, it was back to the ChatGPT to tweak the chat box so it wouldn’t
+grow as messages were added. I asked:
+
+    "I have something like this (it's working now) 
+    [code]
+    The messages are added to this div so it grows over time. 
+    Is there a way I can set it's height to always be 80% of the total window height with a scroll bar if needed?"
+
+Based on this query GPT4o helpfully shared that “This can be achieved
+using Tailwind CSS utility classes. Specifically, you can use h-\[80vh\]
+to set the height to 80% of the viewport height, and overflow-y-auto to
+add a vertical scroll bar when needed.”
+
+To put it another way: none of the CSS classes in the following example
+were written by a human, and what edits I did make were informed by
+advice from the AI that made it relatively painless!
+
+The actual chat functionality of the app is based on our
+[claudette](https://claudette.answer.ai/) library. As with the image
+example, we face a potential hiccup in that getting a response from an
+LLM is slow. We need a way to have the user message added to the UI
+immediately, and then have the response added once it’s available. We
+could do something similar to the image generation example above, or use
+websockets. Check out the [full
+example](https://github.com/AnswerDotAI/fasthtml-example/tree/main/02_chatbot)
+for implementations of both, along with further details.
+
+## Full Example \#4 - Multiplayer Game of Life Example with Websockets
+
+Let’s see how we can implement a collaborative website using Websockets
+in FastHTML. To showcase this, we will use the famous [Conway’s Game of
+Life](https://en.wikipedia.org/wiki/Conway's_Game_of_Life), which is a
+game that takes place in a grid world. Each cell in the grid can be
+either alive or dead. The cell’s state is initially given by a user
+before the game is started and then evolves through the iteration of the
+grid world once the clock starts. Whether a cell’s state will change
+from the previous state depends on simple rules based on its neighboring
+cells’ states. Here is the standard Game of Life logic implemented in
+Python courtesy of ChatGPT:
+
+``` python
+grid = [[0 for _ in range(20)] for _ in range(20)]
+def update_grid(grid: list[list[int]]) -> list[list[int]]:
+    new_grid = [[0 for _ in range(20)] for _ in range(20)]
+    def count_neighbors(x, y):
+        directions = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
+        count = 0
+        for dx, dy in directions:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < len(grid) and 0 <= ny < len(grid[0]): count += grid[nx][ny]
+        return count
+    for i in range(len(grid)):
+        for j in range(len(grid[0])):
+            neighbors = count_neighbors(i, j)
+            if grid[i][j] == 1:
+                if neighbors < 2 or neighbors > 3: new_grid[i][j] = 0
+                else: new_grid[i][j] = 1
+            elif neighbors == 3: new_grid[i][j] = 1
+    return new_grid
+```
+
+This would be a very dull game if we were to run it, since the initial
+state of everything would remain dead. Therefore, we need a way of
+letting the user give an initial state before starting the game.
+FastHTML to the rescue!
+
+``` python
+def Grid():
+    cells = []
+    for y, row in enumerate(game_state['grid']):
+        for x, cell in enumerate(row):
+            cell_class = 'alive' if cell else 'dead'
+            cell = Div(cls=f'cell {cell_class}', hx_put='/update', hx_vals={'x': x, 'y': y}, hx_swap='none', hx_target='#gol', hx_trigger='click')
+            cells.append(cell)
+    return Div(*cells, id='grid')
+
+@rt('/update')
+async def put(x: int, y: int):
+    grid[y][x] = 1 if grid[y][x] == 0 else 0
+```
+
+Above is a component for representing the game’s state that the user can
+interact with and update on the server using cool HTMX features such as
+`hx_vals` for determining which cell was clicked to make it dead or
+alive. Now, you probably noticed that the HTTP request in this case is a
+PUT request, which does not return anything and this means our client’s
+view of the grid world and the server’s game state will immediately
+become out of sync :(. We could of course just return a new Grid
+component with the updated state, but that would only work for a single
+client, if we had more, they quickly get out of sync with each other and
+the server. Now Websockets to the rescue!
+
+Websockets are a way for the server to keep a persistent connection with
+clients and send data to the client without explicitly being requested
+for information, which is not possible with HTTP. Luckily FastHTML and
+HTMX work well with Websockets. Simply state you wish to use websockets
+for your app and define a websocket route:
+
+``` python
+...
+app = FastHTML(hdrs=(picolink, gridlink, css, htmx_ws), exts='ws')
+
+player_queue = []
+async def update_players():
+    for i, player in enumerate(player_queue):
+        try: await player(Grid())
+        except: player_queue.pop(i)
+async def on_connect(send): player_queue.append(send)
+async def on_disconnect(send): await update_players()
+
+@app.ws('/gol', conn=on_connect, disconn=on_disconnect)
+async def ws(msg:str, send): pass
+
+def Home(): return Title('Game of Life'), Main(gol, Div(Grid(), id='gol', cls='row center-xs'), hx_ext="ws", ws_connect="/gol")
+
+@rt('/update')
+async def put(x: int, y: int):
+    grid[y][x] = 1 if grid[y][x] == 0 else 0
+    await update_players()
+...
+```
+
+Here we simply keep track of all the players that have connected or
+disconnected to our site and when an update occurs, we send updates to
+all the players still connected via websockets. Via HTMX, you are still
+simply exchanging HTML from the server to the client and will swap in
+the content based on how you setup your `hx_swap` attribute. There is
+only one difference, that being all swaps are OOB. You can find more
+information on the HTMX websocket extension documentation page
+[here](https://github.com/bigskysoftware/htmx-extensions/blob/main/src/ws/README.md).
+You can find a full fledge hosted example of this app
+[here](https://game-of-life-production-ed7f.up.railway.app/).
+
+## FT objects and HTML
+
+These FT objects create a ‘FastTag’ structure \[tag,children,attrs\] for
+`to_xml()`. When we call `Div(...)`, the elements we pass in are the
+children. Attributes are passed in as keywords. `class` and `for` are
+special words in python, so we use `cls`, `klass` or `_class` instead of
+`class` and `fr` or `_for` instead of `for`. Note these objects are just
+3-element lists - you can create custom ones too as long as they’re also
+3-element lists. Alternately, leaf nodes can be strings instead (which
+is why you can do `Div('some text')`). If you pass something that isn’t
+a 3-element list or a string, it will be converted to a string using
+str()… unless (our final trick) you define a `__ft__` method that will
+run before str(), so you can render things a custom way.
+
+For example, here’s one way we could make a custom class that can be
+rendered into HTML:
+
+``` python
+class Person:
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
+
+    def __ft__(self):
+        return ['div', [f'{self.name} is {self.age} years old.'], {}]
+
+p = Person('Jonathan', 28)
+print(to_xml(Div(p, "more text", cls="container")))
+```
+
+    <div class="container">
+      <div>Jonathan is 28 years old.</div>
+    more text
+    </div>
+
+In the examples, you’ll see we often patch in `__ft__` methods to
+existing classes to control how they’re rendered. For example, if Person
+didn’t have a `__ft__` method or we wanted to override it, we could add
+a new one like this:
+
+``` python
+from fastcore.all import patch
+
+@patch
+def __ft__(self:Person):
+    return Div("Person info:", Ul(Li("Name:",self.name), Li("Age:", self.age)))
+
+show(p)
+```
+
+<div>
+Person info:
+  <ul>
+    <li>
+Name:
+Jonathan
+    </li>
+    <li>
+Age:
+28
+    </li>
+  </ul>
+</div>
+
+Some tags from fastcore.xml are overwritten by fasthtml.core and a few
+are further extended by fasthtml.xtend using this method. Over time, we
+hope to see others developing custom components too, giving us a larger
+and larger ecosystem of reusable components.
+
+## Custom Scripts and Styling
+
+There are many popular JavaScript and CSS libraries that can be used via
+a simple [`Script`](https://docs.fastht.ml/api/xtend.html#script) or
+[`Style`](https://docs.fastht.ml/api/xtend.html#style) tag. But in some
+cases you will need to write more custom code. FastHTML’s
+[js.py](https://github.com/AnswerDotAI/fasthtml/blob/main/fasthtml/js.py)
+contains a few examples that may be useful as reference.
+
+For example, to use the [marked.js](https://marked.js.org/) library to
+render markdown in a div, including in components added after the page
+has loaded via htmx, we do something like this:
+
+``` javascript
+import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
+proc_htmx('%s', e => e.innerHTML = marked.parse(e.textContent));
+```
+
+`proc_htmx` is a shortcut that we wrote to apply a function to elements
+matching a selector, including the element that triggered the event.
+Here’s the code for reference:
+
+``` javascript
+export function proc_htmx(sel, func) {
+  htmx.onLoad(elt => {
+    const elements = htmx.findAll(elt, sel);
+    if (elt.matches(sel)) elements.unshift(elt)
+    elements.forEach(func);
+  });
+}
+```
+
+The [AI Pictionary
+example](https://github.com/AnswerDotAI/fasthtml-example/tree/main/03_pictionary)
+uses a larger chunk of custom JavaScript to handle the drawing canvas.
+It’s a good example of the type of application where running code on the
+client side makes the most sense, but still shows how you can integrate
+it with FastHTML on the server side to add functionality (like the AI
+responses) easily.
+
+Adding styling with custom CSS and libraries such as tailwind is done
+the same way we add custom JavaScript. The [doodle
+example](https://github.com/AnswerDotAI/fasthtml-example/tree/main/doodle)
+uses [Doodle.CSS](https://github.com/chr15m/DoodleCSS) to style the page
+in a quirky way.
+
+## Deploying Your App
+
+We can deploy FastHTML almost anywhere you can deploy python apps. We’ve
+tested Railway, Replit,
+[HuggingFace](https://github.com/AnswerDotAI/fasthtml-hf), and
+[PythonAnywhere](https://github.com/AnswerDotAI/fasthtml-example/blob/main/deploying-to-pythonanywhere.md).
+
+### Railway
+
+1.  [Install the Railway CLI](https://docs.railway.app/guides/cli) and
+    sign up for an account.
+2.  Set up a folder with our app as `main.py`
+3.  In the folder, run `railway login`.
+4.  Use the `fh_railway_deploy` script to deploy our project:
+
+``` bash
+fh_railway_deploy MY_APP_NAME
+```
+
+What the script does for us:
+
+4.  Do we have an existing railway project?
+    - Yes: Link the project folder to our existing Railway project.
+    - No: Create a new Railway project.
+5.  Deploy the project. We’ll see the logs as the service is built and
+    run!
+6.  Fetches and displays the URL of our app.
+7.  By default, mounts a `/app/data` folder on the cloud to our app’s
+    root folder. The app is run in `/app` by default, so from our app
+    anything we store in `/data` will persist across restarts.
+
+A final note about Railway: We can add secrets like API keys that can be
+accessed as environment variables from our apps via
+[‘Variables’](https://docs.railway.app/guides/variables). For example,
+for the [image generation
+app](https://github.com/AnswerDotAI/fasthtml-example/tree/main/image_app_simple),
+we can add a `REPLICATE_API_KEY` variable, and then in `main.py` we can
+access it as `os.environ['REPLICATE_API_KEY']`.
+
+### Replit
+
+Fork [this repl](https://replit.com/@johnowhitaker/FastHTML-Example) for
+a minimal example you can edit to your heart’s content. `.replit` has
+been edited to add the right run command
+(`run = ["uvicorn", "main:app", "--reload"]`) and to set up the ports
+correctly. FastHTML was installed with `poetry add python-fasthtml`, you
+can add additional packages as needed in the same way. Running the app
+in Replit will show you a webview, but you may need to open in a new tab
+for all features (such as cookies) to work. When you’re ready, you can
+deploy your app by clicking the ‘Deploy’ button. You pay for usage - for
+an app that is mostly idle the cost is usually a few cents per month.
+
+You can store secrets like API keys via the ‘Secrets’ tab in the Replit
+project settings.
+
+### HuggingFace
+
+Follow the instructions in [this
+repository](https://github.com/AnswerDotAI/fasthtml-hf) to deploy to
+HuggingFace spaces.
+
+## Where Next?
+
+We’ve covered a lot of ground here! Hopefully this has given you plenty
+to work with in building your own FastHTML apps. If you have any
+questions, feel free to ask in the \#fasthtml Discord channel (in the
+fastai Discord community). You can look through the other examples in
+the [fasthtml-example
+repository](https://github.com/AnswerDotAI/fasthtml-example) for more
+ideas, and keep an eye on Jeremy’s [YouTube
+channel](https://www.youtube.com/@howardjeremyp) where we’ll be
+releasing a number of “dev chats” related to FastHTML in the near
+future.</doc><doc title="Using Jupyter to write FastHTML" desc="A guide to developing FastHTML apps inside Jupyter notebooks."># Using Jupyter to write FastHTML
+
+
+
+Writing FastHTML applications in Jupyter notebooks requires a slightly
+different process than normal Python applications.
+
+<div>
+
+> **Download this notebook and try it yourself**
+>
+> The source code for this page is a [Jupyter
+> notebook](https://github.com/AnswerDotAI/fasthtml/blob/main/nbs/tutorials/jupyter_and_fasthtml.ipynb).
+> That makes it easy to directly experiment with it. However, as this is
+> working code that means we have to comment out a few things in order
+> for the documentation to build.
+
+</div>
+
+The first step is to import necessary libraries. As using FastHTML
+inside a Jupyter notebook is a special case, it remains a special
+import.
+
+``` python
+from fasthtml.common import *
+from fasthtml.jupyter import JupyUvi, HTMX
+```
+
+Let’s create an app with `fast_app`.
+
+``` python
+app, rt = fast_app(pico=True)
+```
+
+Define a route to test the application.
+
+``` python
+@rt
+def index():
+    return Titled('Hello, Jupyter',
+           P('Welcome to the FastHTML + Jupyter example'),
+           Button('Click', hx_get='/click', hx_target='#dest'),
+           Div(id='dest')
+    )
+```
+
+Create a `server` object using
+[`JupyUvi`](https://docs.fastht.ml/api/jupyter.html#jupyuvi), which also
+starts Uvicorn. The `server` runs in a separate thread from Jupyter, so
+it can use normal HTTP client functions in a notebook.
+
+``` python
+server = JupyUvi(app)
+```
+
+<script>
+document.body.addEventListener('htmx:configRequest', (event) => {
+    if(event.detail.path.includes('://')) return;
+    htmx.config.selfRequestsOnly=false;
+    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;
+});
+</script>
+
+The [`HTMX`](https://docs.fastht.ml/api/jupyter.html#htmx) callable
+displays the server’s HTMX application in an iframe which can be
+displayed by Jupyter notebook. Pass in the same `port` variable used in
+the [`JupyUvi`](https://docs.fastht.ml/api/jupyter.html#jupyuvi)
+callable above or leave it blank to use the default (8000).
+
+``` python
+# This doesn't display in the docs - uncomment and run it to see it in action
+# HTMX()
+```
+
+We didn’t define the `/click` route, but that’s fine - we can define (or
+change) it any time, and it’s dynamically inserted into the running app.
+No need to restart or reload anything!
+
+``` python
+@rt
+def click(): return P('You clicked me!')
+```
+
+## Full screen view
+
+You can view your app outside of Jupyter by going to `localhost:PORT`,
+where `PORT` is usually the default 8000, so in most cases just click
+[this link](localhost:8000/).
+
+## Graceful shutdowns
+
+Use the `server.stop()` function displayed below. If you restart Jupyter
+without calling this line the thread may not be released and the
+[`HTMX`](https://docs.fastht.ml/api/jupyter.html#htmx) callable above
+may throw errors. If that happens, a quick temporary fix is to specify a
+different port number in JupyUvi and HTMX with the `port` parameter.
+
+Cleaner solutions to the dangling thread are to kill the dangling thread
+(dependant on each operating system) or restart the computer.
+
+``` python
+server.stop()
+```</doc><doc title="FT Components" desc="Explanation of the `FT` components, which are a way to write HTML in a Pythonic way."># **FT** Components
+
+
+
+**FT**, or ‘FastTags’, are the display components of FastHTML. In fact,
+the word “components” in the context of FastHTML is often synonymous
+with **FT**.
+
+For example, when we look at a FastHTML app, in particular the views, as
+well as various functions and other objects, we see something like the
+code snippet below. It’s the `return` statement that we want to pay
+attention to:
+
+``` python
+from fasthtml.common import *
+
+def example():
+    # The code below is a set of ft components
+    return Div(
+            H1("FastHTML APP"),
+            P("Let's do this"),
+            cls="go"
+    )
+```
+
+Let’s go ahead and call our function and print the result:
+
+``` python
+example()
+```
+
+``` xml
+<div class="go">
+  <h1>FastHTML APP</h1>
+  <p>Let&#x27;s do this</p>
+</div>
+```
+
+As you can see, when returned to the user from a Python callable, like a
+function, the ft components are transformed into their string
+representations of XML or XML-like content such as HTML. More concisely,
+*ft turns Python objects into HTML*.
+
+Now that we know what ft components look and behave like we can begin to
+understand them. At their most fundamental level, ft components:
+
+1.  Are Python callables, specifically functions, classes, methods of
+    classes, lambda functions, and anything else called with parenthesis
+    that returns a value.
+2.  Return a sequence of values which has three elements:
+    1.  The tag to be generated
+    2.  The content of the tag, which is a tuple of strings/tuples. If a
+        tuple, it is the three-element structure of an ft component
+    3.  A dictionary of XML attributes and their values
+3.  FastHTML’s default ft components words begin with an uppercase
+    letter. Examples include `Title()`, `Ul()`, and `Div()` Custom
+    components have included things like `BlogPost` and `CityMap`.
+
+## How FastHTML names ft components
+
+When it comes to naming ft components, FastHTML appears to break from
+PEP8. Specifically, PEP8 specifies that when naming variables, functions
+and instantiated classes we use the `snake_case_pattern`. That is to
+say, lowercase with words separated by underscores. However, FastHTML
+uses `PascalCase` for ft components.
+
+There’s a couple of reasons for this:
+
+1.  ft components can be made from any callable type, so adhering to any
+    one pattern doesn’t make much sense
+2.  It makes for easier reading of FastHTML code, as anything that is
+    PascalCase is probably an ft component
+
+## Default **FT** components
+
+FastHTML has over 150 **FT** components designed to accelerate web
+development. Most of these mirror HTML tags such as `<div>`, `<p>`,
+`<a>`, `<title>`, and more. However, there are some extra tags added,
+including:
+
+- [`Titled`](https://docs.fastht.ml/api/xtend.html#titled), a
+  combination of the `Title()` and `H1()` tags
+- [`Socials`](https://docs.fastht.ml/api/xtend.html#socials), renders
+  popular social media tags
+
+## The `fasthtml.ft` Namespace
+
+Some people prefer to write code using namespaces while adhering to
+PEP8. If that’s a preference, projects can be coded using the
+`fasthtml.ft` namespace.
+
+``` python
+from fasthtml import ft
+
+ft.Ul(
+    ft.Li("one"),
+    ft.Li("two"),
+    ft.Li("three")
+)
+```
+
+``` xml
+<ul>
+  <li>one</li>
+  <li>two</li>
+  <li>three</li>
+</ul>
+```
+
+## Attributes
+
+This example demonstrates many important things to know about how ft
+components handle attributes.
+
+``` python
+#| echo: False
+Label(
+    "Choose an option", 
+    Select(
+        Option("one", value="1", selected=True),
+        Option("two", value="2", selected=False),
+        Option("three", value=3),
+        cls="selector",
+        _id="counter",
+        **{'@click':"alert('Clicked');"},
+    ),
+    _for="counter",
+)
+```
+
+Line 2  
+Line 2 demonstrates that FastHTML appreciates `Label`s surrounding their
+fields.
+
+Line 5  
+On line 5, we can see that attributes set to the `boolean` value of
+`True` are rendered with just the name of the attribute.
+
+Line 6  
+On line 6, we demonstrate that attributes set to the `boolean` value of
+`False` do not appear in the rendered output.
+
+Line 7  
+Line 7 is an example of how integers and other non-string values in the
+rendered output are converted to strings.
+
+Line 8  
+Line 8 is where we set the HTML class using the `cls` argument. We use
+`cls` here as `class` is a reserved word in Python. During the rendering
+process this will be converted to the word “class”.
+
+Line 9  
+Line 9 demonstrates that any named argument passed into an ft component
+will have the leading underscore stripped away before rendering. Useful
+for handling reserved words in Python.
+
+Line 10  
+On line 10 we have an attribute name that cannot be represented as a
+python variable. In cases like these, we can use an unpacked `dict` to
+represent these values.
+
+Line 12  
+The use of `_for` on line 12 is another demonstration of an argument
+having the leading underscore stripped during render. We can also use
+`fr` as that will be expanded to `for`.
+
+This renders the following HTML snippet:
+
+``` python
+Label(
+    "Choose an option", 
+    Select(
+        Option("one", value="1", selected=True),
+        Option("two", value="2", selected=False),
+        Option("three", value=3),  # <4>,
+        cls="selector",
+        _id="counter",
+        **{'@click':"alert('Clicked');"},
+    ),
+    _for="counter",
+)
+```
+
+``` xml
+<label for="counter">
+Choose an option
+  <select id="counter" @click="alert(&#x27;Clicked&#x27;);" class="selector" name="counter">
+    <option value="1" selected>one</option>
+    <option value="2" >two</option>
+    <option value="3">three</option>
+  </select>
+</label>
+```
+
+## Defining new ft components
+
+It is possible and sometimes useful to create your own ft components
+that generate non-standard tags that are not in the FastHTML library.
+FastHTML supports created and defining those new tags flexibly.
+
+For more information, see the [Defining new ft
+components](../ref/defining_xt_component) reference page.
+
+## FT components and type hints
+
+If you use type hints, we strongly suggest that FT components be treated
+as the `Any` type.
+
+The reason is that FastHTML leverages python’s dynamic features to a
+great degree. Especially when it comes to `FT` components, which can
+evaluate out to be `FT|str|None|tuple` as well as anything that supports
+the `__ft__`, `__html__`, and `__str__` method. That’s enough of the
+Python stack that assigning anything but `Any` to be the FT type will
+prove an exercise in frustation.</doc><doc title="FAQ" desc="Answers to common questions about FastHTML."># FAQ
+
+
+
+## Why does my editor say that I have errors in my FastHTML code?
+
+Many editors, including Visual Studio Code, use PyLance to provide error
+checking for Python. However, PyLance’s error checking is just a guess –
+it can’t actually know whether your code is correct or not. PyLance
+particularly struggles with FastHTML’s syntax, which leads to it often
+reporting false error messages in FastHTML projects.
+
+To avoid these misleading error messages, it’s best to disable some
+PyLance error checking in your FastHTML projects. Here’s how to do it in
+Visual Studio Code (the same approach should also work in other editors
+based on vscode, such as Cursor and GitHub Codespaces):
+
+1.  Open your FastHTML project
+2.  Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac) to open the Command
+    Palette
+3.  Type “Preferences: Open Workspace Settings (JSON)” and select it
+4.  In the JSON file that opens, add the following lines:
+
+``` json
+{
+ "python.analysis.diagnosticSeverityOverrides": {
+      "reportGeneralTypeIssues": "none",
+      "reportOptionalMemberAccess": "none",
+      "reportWildcardImportFromLibrary": "none",
+      "reportRedeclaration": "none",
+      "reportAttributeAccessIssue": "none",
+      "reportInvalidTypeForm": "none",
+      "reportAssignmentType": "none",
+  }
+}
+```
+
+5.  Save the file
+
+Even with PyLance diagnostics turned off, your FastHTML code will still
+run correctly. If you’re still seeing some false errors from PyLance,
+you can disable it entirely by adding this to your settings:
+
+``` json
+{
+  "python.analysis.ignore": [  "*"  ]
+}
+```
+
+## Why the distinctive coding style?
+
+FastHTML coding style is the [fastai coding
+style](https://docs.fast.ai/dev/style.html).
+
+If you are coming from a data science background the **fastai coding
+style** may already be your preferred style.
+
+If you are coming from a PEP-8 background where the use of ruff is
+encouraged, there is a learning curve. However, once you get used to the
+**fastai coding style** you may discover yourself appreciating the
+concise nature of this style. It also encourages using more functional
+programming tooling, which is both productive and fun. Having said that,
+it’s entirely optional!
+
+## Why not JSX?
+
+Many have asked! We think there’s no benefit… Python’s positional and kw
+args precisely 1:1 map already to html/xml children and attrs, so
+there’s no need for a new syntax.
+
+We wrote some more thoughts on Why Python HTML components over Jinja2,
+Mako, or JSX
+[here](https://www.answer.ai/posts/2024-08-03-fasthtml.html#why).
+
+## Why use `import *`
+
+First, through the use of the
+[`__all__`](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package)
+attribute in our Python modules we control what actually gets imported.
+So there’s no risk of namespace pollution.
+
+Second, our style lends itself to working in rather compact Jupyter
+notebooks and small Python modules. Hence we know about the source code
+whose libraries we `import *` from. This terseness means we can develop
+faster. We’re a small team, and any edge we can gain is important to us.
+
+Third, for external libraries, be it core Python, SQLAlchemy, or other
+things we do tend to use explicit imports. In part to avoid namespace
+collisions, and also as reference to know where things are coming from.
+
+We’ll finish by saying a lot of our users employ explicit imports. If
+that’s the path you want to take, we encourage the use of
+`from fasthtml import common as fh`. The acronym of `fh` makes it easy
+to recognize that a symbol is from the FastHTML library.
+
+## Can FastHTML be used for dashboards?
+
+Yes it can. In fact, it excels at building dashboards. In addition to
+being great for building static dashboards, because of its
+[foundation](https://about.fastht.ml/foundation) in ASGI and [tech
+stack](https://about.fastht.ml/tech), FastHTML natively supports
+Websockets. That means using FastHTML we can create dashboards that
+autoupdate.
+
+## Why is FastHTML developed using notebooks?
+
+Some people are under the impression that writing software in notebooks
+is bad.
+
+[Watch this
+video](https://www.youtube.com/watch?v=9Q6sLbz37gk&ab_channel=JeremyHoward).
+We’ve used Jupyter notebooks exported via `nbdev` to write a wide range
+of “very serious” software projects over the last three years. This
+includes deep learning libraries, API clients, Python language
+extensions, terminal user interfaces, web frameworks, and more!
+
+[nbdev](https://nbdev.fast.ai/) is a Jupyter-powered tool for writing
+software. Traditional programming environments throw away the result of
+your exploration in REPLs or notebooks. `nbdev` makes exploration an
+integral part of your workflow, all while promoting software engineering
+best practices.
+
+## Why not pyproject.toml for packaging?
+
+FastHTML uses a `setup.py` module instead of a `pyproject.toml` file to
+configure itself for installation. The reason for this is
+`pyproject.toml` is not compatible with [nbdev](https://nbdev.fast.ai/),
+which is what is used to write and build FastHTML.
+
+The nbdev project spent around a year trying to move to pyproject.toml
+but there was insufficient functionality in the toml-based approach to
+complete the transition.</doc><doc title="MiniDataAPI Spec" desc="Explanation of the MiniDataAPI specification, which allows us to use the same API for many different database engines."># MiniDataAPI Spec
+
+
+
+The `MiniDataAPI` is a persistence API specification that designed to be
+small and relatively easy to implement across a wide range of
+datastores. While early implementations have been SQL-based, the
+specification can be quickly implemented in key/value stores, document
+databases, and more.
+
+<div>
+
+> **Work in Progress**
+>
+> The MiniData API spec is a work in progress, subject to change. While
+> the majority of design is complete, expect there could be breaking
+> changes.
+
+</div>
+
+## Why?
+
+The MiniDataAPI specification allows us to use the same API for many
+different database engines. Any application using the MiniDataAPI spec
+for interacting with its database requires no modification beyond import
+and configuration changes to switch database engines. For example, to
+convert an application from Fastlite running SQLite to FastSQL running
+PostgreSQL, should require only changing these two lines:
+
+<div class="columns">
+
+<div class="column" width="19%"
+style="border-right: 1px solid #ccc; padding-right: 10px;">
+
+FastLite version
+
+``` python
+from fastlite import *
+db = database('test.db')
+```
+
+</div>
+
+<div class="column" width="79%" style="padding-left: 10px;">
+
+FastSQL version
+
+``` python
+from fastsql import *
+db = Database('postgres:...')
+```
+
+</div>
+
+</div>
+
+As both libraries adhere to the MiniDataAPI specification, the rest of
+the code in the application should remain the same. The advantage of the
+MiniDataAPI spec is that it allows people to use whatever datastores
+they have access to or prefer.
+
+<div>
+
+> **Note**
+>
+> Switching databases won’t migrate any existing data between databases.
+
+</div>
+
+### Easy to learn, quick to implement
+
+The MiniDataAPI specification is designed to be easy-to-learn and quick
+to implement. It focuses on straightforward Create, Read, Update, and
+Delete (CRUD) operations.
+
+MiniDataAPI databases aren’t limited to just row-based systems. In fact,
+the specification is closer in design to a key/value store than a set of
+records. What’s exciting about this is we can write implementations for
+tools like Python dict stored as JSON, Redis, and even the venerable
+ZODB.
+
+### Limitations of the MiniDataAPI Specification
+
+> “Mini refers to the lightweightness of specification, not the data.”
+>
+> – Jeremy Howard
+
+The advantages of the MiniDataAPI come at a cost. The MiniDataAPI
+specification focuses a very small set of features compared to what can
+be found in full-fledged ORMs and query languages. It intentionally
+avoids nuances or sophisticated features.
+
+This means the specification does not include joins or formal foreign
+keys. Complex data stored over multiple tables that require joins isn’t
+handled well. For this kind of scenario it’s probably for the best to
+use more sophisticated ORMs or even direct database queries.
+
+### Summary of the MiniDataAPI Design
+
+- Easy-to-learn
+- Relative quick to implement for new database engines
+- An API for CRUD operations
+- For many different types of databases including row- and
+  key/value-based designs
+- Intentionally small in terms of features: no joins, no foreign keys,
+  no database specific features
+- Best for simpler designs, complex architectures will need more
+  sophisticated tools.
+
+## Connect/construct the database
+
+We connect or construct the database by passing in a string connecting
+to the database endpoint or a filepath representing the database’s
+location. While this example is for SQLite running in memory, other
+databases such as PostgreSQL, Redis, MongoDB, might instead use a URI
+pointing at the database’s filepath or endpoint. The method of
+connecting to a DB is *not* part of this API, but part of the underlying
+library. For instance, for fastlite:
+
+``` python
+db = database(':memory:')
+```
+
+Here’s a complete list of the available methods in the API, all
+documented below (assuming `db` is a database and `t` is a table):
+
+- `db.create`
+- `t.insert`
+- `t.delete`
+- `t.update`
+- `t[key]`
+- `t(...)`
+- `t.xtra`
+
+## Tables
+
+For the sake of expediency, this document uses a SQL example. However,
+tables can represent anything, not just the fundamental construct of a
+SQL databases. They might represent keys within a key/value structure or
+files on a hard-drive.
+
+### Creating tables
+
+We use a `create()` method attached to `Database` object (`db` in our
+example) to create the tables.
+
+``` python
+class User: name:str; email: str; year_started:int
+users = db.create(User, pk='name')
+users
+```
+
+    <Table user (name, email, year_started)>
+
+``` python
+class User: name:str; email: str; year_started:int
+users = db.create(User, pk='name')
+users
+```
+
+    <Table user (name, email, year_started)>
+
+If no `pk` is provided, `id` is assumed to be the primary key.
+Regardless of whether you mark a class as a dataclass or not, it will be
+turned into one – specifically into a
+[`flexiclass`](https://fastcore.fast.ai/xtras.html#flexiclass).
+
+``` python
+@dataclass
+class Todo: id: int; title: str; detail: str; status: str; name: str
+todos = db.create(Todo) 
+todos
+```
+
+    <Table todo (id, title, detail, status, name)>
+
+### Compound primary keys
+
+The MiniData API spec supports compound primary keys, where more than
+one column is used to identify records. We’ll also use this example to
+demonstrate creating a table using a dict of keyword arguments.
+
+``` python
+class Publication: authors: str; year: int; title: str
+publications = db.create(Publication, pk=('authors', 'year'))
+```
+
+### Transforming tables
+
+Depending on the database type, this method can include transforms - the
+ability to modify the tables. Let’s go ahead and add a password field
+for our table called `pwd`.
+
+``` python
+class User: name:str; email: str; year_started:int; pwd:str
+users = db.create(User, pk='name', transform=True)
+users
+```
+
+    <Table user (name, email, year_started, pwd)>
+
+## Manipulating data
+
+The specification is designed to provide as straightforward CRUD API
+(Create, Read, Update, and Delete) as possible. Additional features like
+joins are out of scope.
+
+### .insert()
+
+Add a new record to the database. We want to support as many types as
+possible, for now we have tests for Python classes, dataclasses, and
+dicts. Returns an instance of the new record.
+
+Here’s how to add a record using a Python class:
+
+``` python
+users.insert(User(name='Braden', email='b@example.com', year_started=2018))
+```
+
+    User(name='Braden', email='b@example.com', year_started=2018, pwd=None)
+
+We can also use keyword arguments directly:
+
+``` python
+users.insert(name='Alma', email='a@example.com', year_started=2019)
+```
+
+    User(name='Alma', email='a@example.com', year_started=2019, pwd=None)
+
+And now Charlie gets added via a Python dict.
+
+``` python
+users.insert({'name': 'Charlie', 'email': 'c@example.com', 'year_started': 2018})
+```
+
+    User(name='Charlie', email='c@example.com', year_started=2018, pwd=None)
+
+And now TODOs. Note that the inserted row is returned:
+
+``` python
+todos.insert(Todo(title='Write MiniDataAPI spec', status='open', name='Braden'))
+todos.insert(title='Implement SSE in FastHTML', status='open', name='Alma')
+todo = todos.insert(dict(title='Finish development of FastHTML', status='closed', name='Charlie'))
+todo
+```
+
+    Todo(id=3, title='Finish development of FastHTML', detail=None, status='closed', name='Charlie')
+
+Let’s do the same with the `Publications` table.
+
+``` python
+publications.insert(Publication(authors='Alma', year=2019, title='FastHTML'))
+publications.insert(authors='Alma', year=2030, title='FastHTML and beyond')
+publication= publications.insert((dict(authors='Alma', year=2035, title='FastHTML, the early years')))
+publication
+```
+
+    Publication(authors='Alma', year=2035, title='FastHTML, the early years')
+
+### Square bracket search \[\]
+
+Get a single record by entering a primary key into a table object within
+square brackets. Let’s see if we can find Alma.
+
+``` python
+user = users['Alma']
+user
+```
+
+    User(name='Alma', email='a@example.com', year_started=2019, pwd=None)
+
+If no record is found, a `NotFoundError` error is raised. Here we look
+for David, who hasn’t yet been added to our users table.
+
+``` python
+try: users['David']
+except NotFoundError: print(f'User not found')
+```
+
+    User not found
+
+Here’s a demonstration of a ticket search, demonstrating how this works
+with non-string primary keys.
+
+``` python
+todos[1]
+```
+
+    Todo(id=1, title='Write MiniDataAPI spec', detail=None, status='open', name='Braden')
+
+Compound primary keys can be supplied in lists or tuples, in the order
+they were defined. In this case it is the `authors` and `year` columns.
+
+Here’s a query by compound primary key done with a `list`:
+
+``` python
+publications[['Alma', 2019]]
+```
+
+    Publication(authors='Alma', year=2019, title='FastHTML')
+
+Here’s the same query done directly with index args.
+
+``` python
+publications['Alma', 2030]
+```
+
+    Publication(authors='Alma', year=2030, title='FastHTML and beyond')
+
+### Parentheses search ()
+
+Get zero to many records by entering values with parentheses searches.
+If nothing is in the parentheses, then everything is returned.
+
+``` python
+users()
+```
+
+    [User(name='Braden', email='b@example.com', year_started=2018, pwd=None),
+     User(name='Alma', email='a@example.com', year_started=2019, pwd=None),
+     User(name='Charlie', email='c@example.com', year_started=2018, pwd=None)]
+
+We can order the results.
+
+``` python
+users(order_by='name')
+```
+
+    [User(name='Alma', email='a@example.com', year_started=2019, pwd=None),
+     User(name='Braden', email='b@example.com', year_started=2018, pwd=None),
+     User(name='Charlie', email='c@example.com', year_started=2018, pwd=None)]
+
+We can filter on the results:
+
+``` python
+users(where="name='Alma'")
+```
+
+    [User(name='Alma', email='a@example.com', year_started=2019, pwd=None)]
+
+Generally you probably want to use placeholders, to avoid SQL injection
+attacks:
+
+``` python
+users("name=?", ('Alma',))
+```
+
+    [User(name='Alma', email='a@example.com', year_started=2019, pwd=None)]
+
+We can limit results with the `limit` keyword:
+
+``` python
+users(limit=1)
+```
+
+    [User(name='Braden', email='b@example.com', year_started=2018, pwd=None)]
+
+If we’re using the `limit` keyword, we can also use the `offset` keyword
+to start the query later.
+
+``` python
+users(limit=5, offset=1)
+```
+
+    [User(name='Alma', email='a@example.com', year_started=2019, pwd=None),
+     User(name='Charlie', email='c@example.com', year_started=2018, pwd=None)]
+
+### .update()
+
+Update an existing record of the database. Must accept Python dict,
+dataclasses, and standard classes. Uses the primary key for identifying
+the record to be changed. Returns an instance of the updated record.
+
+Here’s with a normal Python class:
+
+``` python
+user
+```
+
+    User(name='Alma', email='a@example.com', year_started=2019, pwd=None)
+
+``` python
+user.year_started = 2099
+users.update(user)
+```
+
+    User(name='Alma', email='a@example.com', year_started=2099, pwd=None)
+
+Or use a dict:
+
+``` python
+users.update(dict(name='Alma', year_started=2199, email='a@example.com'))
+```
+
+    User(name='Alma', email='a@example.com', year_started=2199, pwd=None)
+
+Or use kwargs:
+
+``` python
+users.update(name='Alma', year_started=2149)
+```
+
+    User(name='Alma', email='a@example.com', year_started=2149, pwd=None)
+
+If the primary key doesn’t match a record, raise a `NotFoundError`.
+
+John hasn’t started with us yet so doesn’t get the chance yet to travel
+in time.
+
+``` python
+try: users.update(User(name='John', year_started=2024, email='j@example.com'))
+except NotFoundError: print('User not found')
+```
+
+    User not found
+
+### .delete()
+
+Delete a record of the database. Uses the primary key for identifying
+the record to be removed. Returns a table object.
+
+Charlie decides to not travel in time. He exits our little group.
+
+``` python
+users.delete('Charlie')
+```
+
+    <Table user (name, email, year_started, pwd)>
+
+If the primary key value can’t be found, raises a `NotFoundError`.
+
+``` python
+try: users.delete('Charlies')
+except NotFoundError: print('User not found')
+```
+
+    User not found
+
+In John’s case, he isn’t time travelling with us yet so can’t be
+removed.
+
+``` python
+try: users.delete('John')
+except NotFoundError: print('User not found')
+```
+
+    User not found
+
+Deleting records with compound primary keys requires providing the
+entire key.
+
+``` python
+publications.delete(['Alma' , 2035])
+```
+
+    <Table publication (authors, year, title)>
+
+### `in` keyword
+
+Are `Alma` and `John` contained `in` the Users table? Or, to be
+technically precise, is the item with the specified primary key value
+`in` this table?
+
+``` python
+'Alma' in users, 'John' in users
+```
+
+    (True, False)
+
+Also works with compound primary keys, as shown below. You’ll note that
+the operation can be done with either a `list` or `tuple`.
+
+``` python
+['Alma', 2019] in  publications
+```
+
+    True
+
+And now for a `False` result, where John has no publications.
+
+``` python
+('John', 1967) in publications
+```
+
+    False
+
+### .xtra()
+
+If we set fields within the `.xtra` function to a particular value, then
+indexing is also filtered by those. This applies to every database
+method except for record creation. This makes it easier to limit users
+(or other objects) access to only things for which they have permission.
+This is a one-way operation, once set it can’t be undone for a
+particular table object.
+
+For example, if we query all our records below without setting values
+via the `.xtra` function, we can see todos for everyone. Pay special
+attention to the `id` values of all three records, as we are about to
+filter most of them away.
+
+``` python
+todos()
+```
+
+    [Todo(id=1, title='Write MiniDataAPI spec', detail=None, status='open', name='Braden'),
+     Todo(id=2, title='Implement SSE in FastHTML', detail=None, status='open', name='Alma'),
+     Todo(id=3, title='Finish development of FastHTML', detail=None, status='closed', name='Charlie')]
+
+Let’s use `.xtra` to constrain results just to Charlie. We set the
+`name` field in Todos, but it could be any field defined for this table.
+
+``` python
+todos.xtra(name='Charlie')
+```
+
+We’ve now set a field to a value with `.xtra`, if we loop over all the
+records again, only those assigned to records with a `name` of `Charlie`
+will be displayed.
+
+``` python
+todos()
+```
+
+    [Todo(id=3, title='Finish development of FastHTML', detail=None, status='closed', name='Charlie')]
+
+The `in` keyword is also affected. Only records with a `name` of Charlie
+will evaluate to be `True`. Let’s demonstrate by testing it with a
+Charlie record:
+
+``` python
+ct = todos[3]
+ct
+```
+
+    Todo(id=3, title='Finish development of FastHTML', detail=None, status='closed', name='Charlie')
+
+Charlie’s record has an ID of 3. Here we demonstrate that Charlie’s TODO
+can be found in the list of todos:
+
+``` python
+ct.id in todos
+```
+
+    True
+
+If we try `in` with the other IDs the query fails because the filtering
+is now set to just records with a name of Charlie.
+
+``` python
+1 in todos, 2 in todos
+```
+
+    (False, False)
+
+``` python
+try: todos[2]
+except NotFoundError: print('Record not found')
+```
+
+    Record not found
+
+We are also constrained by what records we can update. In the following
+example we try to update a TODO not named ‘Charlie’. Because the name is
+wrong, the `.update` function will raise a `NotFoundError`.
+
+``` python
+try: todos.update(Todo(id=1, title='Finish MiniDataAPI Spec', status='closed', name='Braden'))
+except NotFoundError as e: print('Record not updated')
+```
+
+    Record not updated
+
+Unlike poor Braden, Charlie isn’t filtered out. Let’s update his TODO.
+
+``` python
+todos.update(Todo(id=3, title='Finish development of FastHTML', detail=None, status='closed', name='Charlie'))
+```
+
+    Todo(id=3, title='Finish development of FastHTML', detail=None, status='closed', name='Charlie')
+
+Finally, once constrained by `.xtra`, only records with Charlie as the
+name can be deleted.
+
+``` python
+try: todos.delete(1)
+except NotFoundError as e: print('Record not updated')
+```
+
+    Record not updated
+
+Charlie’s TODO was to finish development of FastHTML. While the
+framework will stabilize, like any good project it will see new features
+added and the odd bug corrected for many years to come. Therefore,
+Charlie’s TODO is nonsensical. Let’s delete it.
+
+``` python
+todos.delete(ct.id)
+```
+
+    <Table todo (id, title, detail, status, name)>
+
+When a TODO is inserted, the `xtra` fields are automatically set. This
+ensures that we don’t accidentally, for instance, insert items for
+others users. Note that here we don’t set the `name` field, but it’s
+still included in the resultant row:
+
+``` python
+ct = todos.insert(Todo(title='Rewrite personal site in FastHTML', status='open'))
+ct
+```
+
+    Todo(id=3, title='Rewrite personal site in FastHTML', detail=None, status='open', name='Charlie')
+
+If we try to change the username to someone else, the change is ignored,
+due to `xtra`:
+
+``` python
+ct.name = 'Braden'
+todos.update(ct)
+```
+
+    Todo(id=3, title='Rewrite personal site in FastHTML', detail=None, status='open', name='Charlie')
+
+## SQL-first design
+
+``` python
+users = None
+User = None
+```
+
+``` python
+users = db.t.user
+users
+```
+
+    <Table user (name, email, year_started, pwd)>
+
+(This section needs to be documented properly.)
+
+From the table objects we can extract a Dataclass version of our tables.
+Usually this is given an singular uppercase version of our table name,
+which in this case is `User`.
+
+``` python
+User = users.dataclass()
+```
+
+``` python
+User(name='Braden', email='b@example.com', year_started=2018)
+```
+
+    User(name='Braden', email='b@example.com', year_started=2018, pwd=UNSET)
+
+## Implementations
+
+### Implementing MiniDataAPI for a new datastore
+
+For creating new implementations, the code examples in this
+specification are the test case for the API. New implementations should
+pass the tests in order to be compliant with the specification.
+
+### Implementations
+
+- [fastlite](https://github.com/AnswerDotAI/fastlite) - The original
+  implementation, only for Sqlite
+- [fastsql](https://github.com/AnswerDotAI/fastsql) - An SQL database
+  agnostic implementation based on the excellent SQLAlchemy library.</doc><doc title="OAuth" desc="Tutorial and explanation of how to use OAuth in FastHTML apps."># OAuth
+
+
+
+OAuth is an open standard for ‘access delegation’, commonly used as a
+way for Internet users to grant websites or applications access to their
+information on other websites but without giving them the passwords. It
+is the mechanism that enables “Log in with Google” on many sites, saving
+you from having to remember and manage yet another password. Like many
+auth-related topics, there’s a lot of depth and complexity to the OAuth
+standard, but once you understand the basic usage it can be a very
+convenient alternative to managing your own user accounts.
+
+On this page you’ll see how to use OAuth with FastHTML to implement some
+common pieces of functionality.
+
+## Creating an Client
+
+FastHTML has Client classes for managing settings and state for
+different OAuth providers. Currently implemented are: GoogleAppClient,
+GitHubAppClient, HuggingFaceClient and DiscordAppClient - see the
+[source](https://github.com/AnswerDotAI/fasthtml/blob/main/nbs/api/08_oauth.ipynb)
+if you need to add other providers. You’ll need a `client_id` and
+`client_secret` from the provider (see the from-scratch example later in
+this page for an example of registering with GitHub) to create the
+client. We recommend storing these in environment variables, rather than
+hardcoding them in your code.
+
+``` python
+import os
+from fasthtml.oauth import GoogleAppClient
+client = GoogleAppClient(os.getenv("AUTH_CLIENT_ID"),
+                         os.getenv("AUTH_CLIENT_SECRET"))
+```
+
+The client is used to obtain a login link and to manage communications
+between your app and the OAuth provider
+(`client.login_link(redirect_uri="/redirect")`).
+
+## Using the OAuth class
+
+Once you’ve set up a client, adding OAuth to a FastHTML app can be as
+simple as:
+
+``` python
+from fasthtml.oauth import OAuth
+from fasthtml.common import FastHTML, RedirectResponse
+
+class Auth(OAuth):
+    def get_auth(self, info, ident, session, state):
+        email = info.email or ''
+        if info.email_verified and email.split('@')[-1]=='answer.ai':
+            return RedirectResponse('/', status_code=303)
+
+app = FastHTML()
+oauth = Auth(app, client)
+
+@app.get('/')
+def home(auth): return P('Logged in!'), A('Log out', href='/logout')
+
+@app.get('/login')
+def login(req): return Div(P("Not logged in"), A('Log in', href=oauth.login_link(req)))
+```
+
+There’s a fair bit going on here, so let’s unpack what’s happening in
+that code:
+
+- OAuth (and by extension our custom Auth class) has a number of default
+  arguments, including some key URLs:
+  `redir_path='/redirect', error_path='/error', logout_path='/logout', login_path='/login'`.
+  It will create and handle the redirect and logout paths, and it’s up
+  to you to handle `/login` (where unsuccessful login attempts will be
+  redirected) and `/error` (for oauth errors).
+- When we run `oauth = Auth(app, client)` it adds the redirect and
+  logout paths to the app and also adds some beforeware. This beforeware
+  runs on any requests (apart from any specified with the `skip`
+  parameter).
+
+The added beforeware specifies some app behaviour:
+
+- If someone who isn’t logged in attempts to visit our homepage (`/`)
+  here, they will be redirected to `/login`.
+- If they are logged in, it calls a `check_invalid` method. This
+  defaults to False, which let’s the user continue to the page they
+  requested. The behaviour can be modified by defining your own
+  `check_invalid` method in the Auth class - for example, you could have
+  this forcibly log out users who have recently been banned.
+
+So how does someone log in? If they visit (or are redirected to) the
+login page at `/login`, we show them a login link. This sends them to
+the OAuth provider, where they’ll go through the steps of selecting
+their account, giving permissions etc. Once done they will be redirected
+back to `/redirect`. Behind the scenes a code that comes as part of
+their request gets turned into user info, which is then passed to the
+key function `get_auth(self, info, ident, session, state)`. Here is
+where you’d handle looking up or adding a user in a database, checking
+for some condition (for example, this code checks if the email is an
+answer.ai email address) or choosing the destination based on state. The
+arguments are:
+
+- `self`: the Auth object, which you can use to access the client
+  (`self.cli`)
+- `info`: the information provided by the OAuth provider, typically
+  including a unique user id, email address, username and other
+  metadata.
+- `ident`: a unique identifier for this user. What this looks like
+  varies between providers. This is useful for managing a database of
+  users, for example.
+- `session`: the current session, that you can store information in
+  securely
+- `state`: you can optionally pass in some state when creating the login
+  link. This persists and is returned after the user goes through the
+  Oath steps, which is useful for returning them to the same page they
+  left. It can also be used as added security against CSRF attacks.
+
+In our example, we check the email in `info` (we use a GoogleAppClient,
+not all providers will include an email). If we aren’t happy, and
+get_auth returns False or nothing (as in the case here for non-answerai
+people) then the user is redirected back to the login page. But if
+everything looks good we return a redirect to the homepage, and an
+`auth` key is added to the session and the scope containing the users
+identity `ident`. So, for example, in the homepage route we could use
+`auth` to look up this particular user’s profile info and customize the
+page accordingly. This auth will persist in their session until they
+clear the browser cache, so by default they’ll stay logged in. To log
+them out, remove it ( `session.pop('auth', None)`) or send them to
+`/logout` which will do that for you.
+
+## Explaining OAuth with a from-scratch implementation
+
+Hopefully the example above is enough to get you started. You can also
+check out the (fairly minimal) [source
+code](https://github.com/AnswerDotAI/fasthtml/blob/main/nbs/api/08_oauth.ipynb)
+where this is implemented, and the [examples
+here](https://github.com/AnswerDotAI/fasthtml-example/blob/main/oauth_example).
+
+If you’re wanting to learn more about how this works, and to see where
+you might add additional functionality, the rest of this page will walk
+through some examples **without** the OAuth convenience class, to
+illustrate the concepts. This was writted before said OAuth class was
+available, and is kep here for educational purposes - we recommend you
+stick with the new approach shown above in most cases.
+
+## A Minimal Login Flow (GitHub)
+
+Let’s begin by building a minimal ‘Sign in with GitHub’ flow. This will
+demonstrate the basic steps of OAuth.
+
+OAuth requires a “provider” (in this case, GitHub) to authenticate the
+user. So the first step when setting up our app is to register with
+GitHub to set things up.
+
+Go to https://github.com/settings/developers and click “New OAuth App”.
+Fill in the form with the following values, then click ‘Register
+application’.
+
+- Application name: Your app name
+- Homepage URL: http://localhost:8000 (or whatever URL you’re using -
+  you can change this later)
+- Authorization callback URL: http://localhost:8000/auth_redirect (you
+  can modify this later too)
+
+<div style="text-align:center;margin:50px 0 45px;">
+
+<img src="imgs/gh-oauth.png" alt="Setting up an OAuth app in GitHub" width="500" />
+
+</div>
+
+After you register, you’ll see a screen where you can view the client ID
+and generate a client secret. Store these values in a safe place. You’ll
+use them to create a
+[`GitHubAppClient`](https://docs.fastht.ml/api/oauth.html#githubappclient)
+object in FastHTML.
+
+This `client` object is responsible for handling the parts of the OAuth
+flow which depend on direct communication between your app and GitHub,
+as opposed to interactions which go through the user’s browser via
+redirects.
+
+Here is how to setup the client object:
+
+``` python
+client = GitHubAppClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret"
+)
+```
+
+You should also save the path component of the authorization callback
+URL which you provided on registration.
+
+This route is where GitHub will redirect the user’s browser in order to
+send an authorization code to your app. You should save only the URL’s
+path component rather than the entire URL because you want your code to
+work automatically in deployment, when the host and port part of the URL
+change from `localhost:8000` to your real DNS name.
+
+Save the special authorization callback path under an obvious name:
+
+``` python
+auth_callback_path = "/auth_redirect"
+```
+
+<div>
+
+> **Note**
+>
+> It’s recommended to store the client ID, and secret, in environment
+> variables, rather than hardcoding them in your code.
+
+</div>
+
+When the user visit a normal page of your app, if they are not already
+logged in, then you’ll want to redirect them to your app’s login page,
+which will live at the `/login` path. We accomplish that by using this
+piece of “beforeware”, which defines logic which runs before other work
+for all routes except ones we specify to be skipped:
+
+``` python
+def before(req, session):
+    auth = req.scope['auth'] = session.get('user_id', None)
+    if not auth: return RedirectResponse('/login', status_code=303)
+    counts.xtra(name=auth)
+bware = Beforeware(before, skip=['/login', auth_callback_path])
+```
+
+We configure the beforeware to skip `/login` because that’s where the
+user goes to login, and we also skip the special authorization callback
+path because that is used by OAuth itself to receive information from
+GitHub.
+
+It’s only at your login page that we start the OAuth flow. To start the
+OAuth flow, you need to give the user a link to GitHub’s login for your
+app. You’ll need the `client` object to generate that link, and the
+client object will in turn need the full authorization callback URL,
+which we need to build from the authorization callback path, so it is a
+multi-step process to produce this GitHub login link.
+
+Here is an implementation of your own `/login` route handler. It
+generates the GitHub login link and presents it to the user:
+
+``` python
+@app.get('/login')
+def login(request)
+    redir = redir_url(request,auth_callback_path)
+    login_link = client.login_link(redir)
+    return P(A('Login with GitHub', href=login_link))    
+```
+
+Once the user follows that link, GitHub will ask them to grant
+permission to your app to access their GitHub account. If they agree,
+GitHub will redirect them back to your app’s authorization callback URL,
+carrying an authorization code which your app can use to generate an
+access token. To receive this code, you need to set up a route in
+FastHTML that listens for requests at the authorization callback path.
+For example:
+
+``` python
+@app.get(auth_callback_path)
+def auth_redirect(code:str):
+    return P(f"code: {code}")
+```
+
+This authorization code is temporary, and is used by your app to
+directly ask the provider for user information like an access token.
+
+To recap, you can think of the exchange so far as:
+
+- User to us: “I want to log in with you, app.”
+- Us to User: “Okay but first, here’s a special link to log in with
+  GitHub”
+- User to GitHub: “I want to log in with you, GitHub, to use this app.”
+- GitHub to User: “OK, redirecting you back to the app’s URL (with an
+  auth code)”
+- User to Us: “Hi again, app. Here’s the GitHub auth code you need to
+  ask GitHub for info about me” (delivered via
+  `/auth_redirect?code=...`)
+
+The final steps we need to implement are as follows:
+
+- Us to GitHUb: “A user just gave me this auth code. May I have the user
+  info (e.g., an access token)?”
+- GitHub to us: “Since you have an auth code, here’s the user info”
+
+It’s critical for us to derive the user info from the auth code
+immediately in the authorization callback, because the auth code may be
+used only once. So we use it that once in order to get information like
+an access token, which will remain valid for longer.
+
+To go from the auth code to user info, you use
+`info = client.retr_info(code,redirect_uri)`. From the user info, you
+can extract the `user_id`, which is a unique identifier for the user:
+
+``` python
+@app.get(auth_callback_path)
+def auth_redirect(code:str, request):
+    redir = redir_url(request, auth_callback_path)
+    user_info = client.retr_info(code, redir)
+    user_id = info[client.id_key]
+    return P(f"User id: {user_id}")
+```
+
+But we want the user ID not to print it but to remember the user.
+
+So let us store it in the `session` object, to remember who is logged
+in:
+
+``` python
+@app.get(auth_callback_path)
+def auth_redirect(code:str, request, session):
+    redir = redir_url(request, auth_callback_path)
+    user_info = client.retr_info(code, redir)
+    user_id = user_info[client.id_key] # get their ID
+    session['user_id'] = user_id # save ID in the session
+    return RedirectResponse('/', status_code=303)
+```
+
+The session object is derived from values visible to the user’s browser,
+but it is cryptographically signed so the user can’t read it themselves.
+This makes it safe to store even information we don’t want to expose to
+the user.
+
+For larger quantities of data, we’d want to save that information in a
+database and use the session to hold keys to lookup information from
+that database.
+
+Here’s a minimal app that puts all these pieces together. It uses the
+user info to get the user_id. It stores that in the session object. It
+then uses the user_id as a key into a database, which tracks how
+frequently every user has hit an increment button.
+
+``` python
+import os
+from fasthtml.common import *
+from fasthtml.oauth import GitHubAppClient, redir_url
+
+db = database('data/counts.db')
+counts = db.t.counts
+if counts not in db.t: counts.create(dict(name=str, count=int), pk='name')
+Count = counts.dataclass()
+
+# Auth client setup for GitHub
+client = GitHubAppClient(os.getenv("AUTH_CLIENT_ID"), 
+                         os.getenv("AUTH_CLIENT_SECRET"))
+auth_callback_path = "/auth_redirect"
+
+def before(req, session):
+    # if not logged in, we send them to our login page
+    # logged in means:
+    # - 'user_id' in the session object, 
+    # - 'auth' in the request object
+    auth = req.scope['auth'] = session.get('user_id', None)
+    if not auth: return RedirectResponse('/login', status_code=303)
+    counts.xtra(name=auth)
+bware = Beforeware(before, skip=['/login', auth_callback_path])
+
+app = FastHTML(before=bware)
+
+# User asks us to Login
+@app.get('/login')
+def login(request):
+    redir = redir_url(request,auth_callback_path)
+    login_link = client.login_link(redir)
+    # we tell user to login at github
+    return P(A('Login with GitHub', href=login_link))    
+
+# User comes back to us with an auth code from Github
+@app.get(auth_callback_path)
+def auth_redirect(code:str, request, session):
+    redir = redir_url(request, auth_callback_path)
+    user_info = client.retr_info(code, redir)
+    user_id = user_info[client.id_key] # get their ID
+    session['user_id'] = user_id # save ID in the session
+    # create a db entry for the user
+    if user_id not in counts: counts.insert(name=user_id, count=0)
+    return RedirectResponse('/', status_code=303)
+
+@app.get('/')
+def home(auth):
+    return Div(
+        P("Count demo"),
+        P(f"Count: ", Span(counts[auth].count, id='count')),
+        Button('Increment', hx_get='/increment', hx_target='#count'),
+        P(A('Logout', href='/logout'))
+    )
+
+@app.get('/increment')
+def increment(auth):
+    c = counts[auth]
+    c.count += 1
+    return counts.upsert(c).count
+
+@app.get('/logout')
+def logout(session):
+    session.pop('user_id', None)
+    return RedirectResponse('/login', status_code=303)
+
+serve()
+```
+
+Some things to note:
+
+- The `before` function is used to check if the user is authenticated.
+  If not, they are redirected to the login page.
+- To log the user out, we remove the user ID from the session.
+- Calling `counts.xtra(name=auth)` ensures that only the row
+  corresponding to the current user is accessible when responding to a
+  request. This is often nicer than trying to remember to filter the
+  data in every route, and lowers the risk of accidentally leaking data.
+- In the `auth_redirect` route, we store the user ID in the session and
+  create a new row in the `user_counts` table if it doesn’t already
+  exist.
+
+You can find more heavily-commented version of this code in the [oauth
+directory in
+fasthtml-example](https://github.com/AnswerDotAI/fasthtml-example/tree/main/oauth_example),
+along with an even more minimal example. More examples may be added in
+the future.
+
+### Revoking Tokens (Google)
+
+When the user in the example above logs out, we remove their user ID
+from the session. However, the user is still logged in to GitHub. If
+they click ‘Login with GitHub’ again, they’ll be redirected back to our
+site without having to log in again. This is because GitHub remembers
+that they’ve already granted our app permission to access their account.
+Most of the time this is convenient, but for testing or security
+purposes you may want a way to revoke this permission.
+
+As a user, you can usually revoke access to an app from the provider’s
+website (for example, <https://github.com/settings/applications>). But
+as a developer, you can also revoke access programmatically - at least
+with some providers. This requires keeping track of the access token
+(stored in `client.token["access_token"]` after you call `retr_info`),
+and sending a request to the provider’s revoke URL:
+
+``` python
+auth_revoke_url = "https://accounts.google.com/o/oauth2/revoke"
+def revoke_token(token):
+    response = requests.post(auth_revoke_url, params={"token": token})
+    return response.status_code == 200 # True if successful
+```
+
+Not all providers support token revocation, and it is not built into
+FastHTML clients at the moment.
+
+### Using State (Hugging Face)
+
+Imagine a user (not logged in) comes to your AI image editing site,
+starts testing things out, and then realizes they need to sign in before
+they can click “Run (Pro)” on the edit they’re working on. They click
+“Sign in with Hugging Face”, log in, and are redirected back to your
+site. But now they’ve lost their in-progress edit and are left just
+looking at the homepage! This is an example of a case where you might
+want to keep track of some additional state. Another strong use case for
+being able to pass some uniqie state through the OAuth flow is to
+prevent something called a [CSRF
+attack](https://en.wikipedia.org/wiki/Cross-site_request_forgery). To
+add a state string to the OAuth flow, you can use
+`client.login_link_with_state(state)` instead of `client.login_link()`,
+like so:
+
+``` python
+# in login page:
+link = A('Login with GitHub', href=client.login_link_with_state(state='current_prompt: add a unicorn'))
+
+# in auth_redirect:
+@app.get('/auth_redirect')
+def auth_redirect(code:str, session, state:str=None):
+    print(f"state: {state}") # Use as needed
+    ...
+```
+
+The state string is passed through the OAuth flow and back to your site.
+
+### A Work in Progress
+
+This page (and OAuth support in FastHTML) is a work in progress.
+Questions, PRs, and feedback are welcome!</doc><doc title="Routes" desc="Explanation of how routes work in FastHTML."># Routes
+
+
+
+Behaviour in FastHTML apps is defined by routes. The syntax is largely
+the same as the wonderful [FastAPI](https://fastapi.tiangolo.com/)
+(which is what you should be using instead of this if you’re creating a
+JSON service. FastHTML is mainly for making HTML web apps, not APIs).
+
+<div>
+
+> **Unfinished**
+>
+> We haven’t yet written complete documentation of all of FastHTML’s
+> routing features – until we add that, the best place to see all the
+> available functionality is to look over [the
+> tests](../api/core.html#tests)
+
+</div>
+
+Note that you need to include the types of your parameters, so that
+[`FastHTML`](https://docs.fastht.ml/api/core.html#fasthtml) knows what
+to pass to your function. Here, we’re just expecting a string:
+
+``` python
+from fasthtml.common import *
+```
+
+``` python
+app = FastHTML()
+
+@app.get('/user/{nm}')
+def get_nm(nm:str): return f"Good day to you, {nm}!"
+```
+
+Normally you’d save this into a file such as main.py, and then run it in
+`uvicorn` using:
+
+    uvicorn main:app
+
+However, for testing, we can use Starlette’s `TestClient` to try it out:
+
+``` python
+from starlette.testclient import TestClient
+```
+
+``` python
+client = TestClient(app)
+r = client.get('/user/Jeremy')
+r
+```
+
+    <Response [200 OK]>
+
+TestClient uses `httpx` behind the scenes, so it returns a
+`httpx.Response`, which has a `text` attribute with our response body:
+
+``` python
+r.text
+```
+
+    'Good day to you, Jeremy!'
+
+In the previous example, the function name (`get_nm`) didn’t actually
+matter – we could have just called it `_`, for instance, since we never
+actually call it directly. It’s just called through HTTP. In fact, we
+often do call our functions `_` when using this style of route, since
+that’s one less thing we have to worry about, naming.
+
+An alternative approach to creating a route is to use `app.route`
+instead, in which case, you make the function name the HTTP method you
+want. Since this is such a common pattern, you might like to give a
+shorter name to `app.route` – we normally use `rt`:
+
+``` python
+rt = app.route
+
+@rt('/')
+def post(): return "Going postal!"
+
+client.post('/').text
+```
+
+    'Going postal!'
+
+### Route-specific functionality
+
+FastHTML supports custom decorators for adding specific functionality to
+routes. This allows you to implement authentication, authorization,
+middleware, or other custom behaviors for individual routes.
+
+Here’s an example of a basic authentication decorator:
+
+``` python
+from functools import wraps
+
+def basic_auth(f):
+    @wraps(f)
+    async def wrapper(req, *args, **kwargs):
+        token = req.headers.get("Authorization")
+        if token == 'abc123':
+            return await f(req, *args, **kwargs)
+        return Response('Not Authorized', status_code=401)
+    return wrapper
+
+@app.get("/protected")
+@basic_auth
+async def protected(req):
+    return "Protected Content"
+
+client.get('/protected', headers={'Authorization': 'abc123'}).text
+```
+
+    'Protected Content'
+
+The decorator intercepts the request before the route function executes.
+If the decorator allows the request to proceed, it calls the original
+route function, passing along the request and any other arguments.
+
+One of the key advantages of this approach is the ability to apply
+different behaviors to different routes. You can also stack multiple
+decorators on a single route for combined functionality.
+
+``` python
+def app_beforeware():
+    print('App level beforeware')
+
+app = FastHTML(before=Beforeware(app_beforeware))
+client = TestClient(app)
+
+def route_beforeware(f):
+    @wraps(f)
+    async def decorator(*args, **kwargs):
+        print('Route level beforeware')
+        return await f(*args, **kwargs)
+    return decorator
+    
+def second_route_beforeware(f):
+    @wraps(f)
+    async def decorator(*args, **kwargs):
+        print('Second route level beforeware')
+        return await f(*args, **kwargs)
+    return decorator
+
+@app.get("/users")
+@route_beforeware
+@second_route_beforeware
+async def users():
+    return "Users Page"
+
+client.get('/users').text
+```
+
+    App level beforeware
+    Route level beforeware
+    Second route level beforeware
+
+    'Users Page'
+
+This flexiblity allows for granular control over route behaviour,
+enabling you to tailor each endpoint’s functionality as needed. While
+app-level beforeware remains useful for global operations, decorators
+provide a powerful tool for route-specific customization.
+
+## Combining Routes
+
+Sometimes a FastHTML project can grow so weildy that putting all the
+routes into `main.py` becomes unweildy. Or, we install a FastHTML- or
+Starlette-based package that requires us to add routes.
+
+First let’s create a `books.py` module, that represents all the
+user-related views:
+
+``` python
+# books.py
+books_app, rt = fast_app()
+
+books = ['A Guide to FastHTML', 'FastHTML Cookbook', 'FastHTML in 24 Hours']
+
+@rt("/", name="list")
+def get():
+    return Titled("Books", *[P(book) for book in books])
+```
+
+Let’s mount it in our main module:
+
+``` python
+from books import books_app
+
+app, rt = fast_app(routes=[Mount("/books", books_app, name="books")])
+
+@rt("/")
+def get():
+    return Titled("Dashboard",
+        P(A(href="/books")("Books")),
+        Hr(),
+        P(A(link=uri("books:list"))("Books")),
+    )
+
+serve()
+```
+
+Line 3  
+We use `starlette.Mount` to add the route to our routes list. We provide
+the name of `books` to make discovery and management of the links
+easier. More on that in items 2 and 3 of this annotations list
+
+Line 8  
+This example link to the books list view is hand-crafted. Obvious in
+purpose, it makes changing link patterns in the future harder
+
+Line 10  
+This example link uses the named URL route for the books. The advantage
+of this approach is it makes management of large numbers of link items
+easier.</doc><doc title="WebSockets" desc="Explanation of websockets and how they work in FastHTML."><!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
+
+<meta charset="utf-8">
+<meta name="generator" content="quarto-1.6.40">
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+
+<title>WebSockets – fasthtml</title>
+<style>
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+  width: 0.8em;
+  margin: 0 0.8em 0.2em -1em; /* quarto-specific, see https://github.com/quarto-dev/quarto-cli/issues/4556 */ 
+  vertical-align: middle;
+}
+/* CSS for syntax highlighting */
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+  }
+pre.numberSource { margin-left: 3em;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+</style>
+
+
+<script src="../site_libs/quarto-nav/quarto-nav.js"></script>
+<script src="../site_libs/quarto-nav/headroom.min.js"></script>
+<script src="../site_libs/clipboard/clipboard.min.js"></script>
+<script src="../site_libs/quarto-search/autocomplete.umd.js"></script>
+<script src="../site_libs/quarto-search/fuse.min.js"></script>
+<script src="../site_libs/quarto-search/quarto-search.js"></script>
+<meta name="quarto:offset" content="../">
+<link href="../favicon.ico" rel="icon">
+<script src="../site_libs/quarto-html/quarto.js"></script>
+<script src="../site_libs/quarto-html/popper.min.js"></script>
+<script src="../site_libs/quarto-html/tippy.umd.min.js"></script>
+<script src="../site_libs/quarto-html/anchor.min.js"></script>
+<link href="../site_libs/quarto-html/tippy.css" rel="stylesheet">
+<link href="../site_libs/quarto-html/quarto-syntax-highlighting-549806ee2085284f45b00abea8c6df48.css" rel="stylesheet" id="quarto-text-highlighting-styles">
+<script src="../site_libs/bootstrap/bootstrap.min.js"></script>
+<link href="../site_libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
+<link href="../site_libs/bootstrap/bootstrap-b12578cb283c490d3e637e8d6dd1ac43.min.css" rel="stylesheet" append-hash="true" id="quarto-bootstrap" data-mode="light">
+<script id="quarto-search-options" type="application/json">{
+  "location": "navbar",
+  "copy-button": false,
+  "collapse-after": 3,
+  "panel-placement": "end",
+  "type": "overlay",
+  "limit": 50,
+  "keyboard-shortcut": [
+    "f",
+    "/",
+    "s"
+  ],
+  "show-item-context": false,
+  "language": {
+    "search-no-results-text": "No results",
+    "search-matching-documents-text": "matching documents",
+    "search-copy-link-title": "Copy link to search",
+    "search-hide-matches-text": "Hide additional matches",
+    "search-more-match-text": "more match in this document",
+    "search-more-matches-text": "more matches in this document",
+    "search-clear-button-title": "Clear",
+    "search-text-placeholder": "",
+    "search-detached-cancel-button-title": "Cancel",
+    "search-submit-button-title": "Submit",
+    "search-label": "Search"
+  }
+}</script>
+
+
+<link rel="stylesheet" href="../styles.css">
+<meta property="og:title" content="WebSockets – fasthtml">
+<meta property="og:description" content="The fastest way to create an HTML app">
+<meta property="og:site_name" content="fasthtml">
+<meta name="twitter:title" content="WebSockets – fasthtml">
+<meta name="twitter:description" content="The fastest way to create an HTML app">
+<meta name="twitter:image" content="https://docs.fastht.ml/og-image.png">
+<meta name="twitter:creator" content="@jeremyphoward">
+<meta name="twitter:site" content="@answerdotai">
+<meta name="twitter:card" content="summary_large_image">
+</head>
+
+<body class="nav-sidebar floating nav-fixed">
+
+<div id="quarto-search-results"></div>
+  <header id="quarto-header" class="headroom fixed-top">
+    <nav class="navbar navbar-expand-lg " data-bs-theme="dark">
+      <div class="navbar-container container-fluid">
+      <div class="navbar-brand-container mx-auto">
+    <a href="../index.html" class="navbar-brand navbar-brand-logo">
+    <img src="../logo.svg" alt="" class="navbar-logo">
+    </a>
+  </div>
+            <div id="quarto-search" class="" title="Search"></div>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" role="menu" aria-expanded="false" aria-label="Toggle navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
+  <span class="navbar-toggler-icon"></span>
+</button>
+          <div class="collapse navbar-collapse" id="navbarCollapse">
+            <ul class="navbar-nav navbar-nav-scroll me-auto">
+  <li class="nav-item">
+    <a class="nav-link" href="https://fastht.ml"> 
+<span class="menu-text">Home</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="https://about.fastht.ml"> 
+<span class="menu-text">Learn</span></a>
+  </li>  
+</ul>
+            <ul class="navbar-nav navbar-nav-scroll ms-auto">
+  <li class="nav-item compact">
+    <a class="nav-link" href="https://github.com/answerdotai/fasthtml"> <i class="bi bi-github" role="img">
+</i> 
+<span class="menu-text"></span></a>
+  </li>  
+  <li class="nav-item compact">
+    <a class="nav-link" href="https://x.com/answerdotai"> <i class="bi bi-twitter" role="img" aria-label="Fast.ai Twitter">
+</i> 
+<span class="menu-text"></span></a>
+  </li>  
+</ul>
+          </div> <!-- /navcollapse -->
+            <div class="quarto-navbar-tools">
+</div>
+      </div> <!-- /container-fluid -->
+    </nav>
+  <nav class="quarto-secondary-nav">
+    <div class="container-fluid d-flex">
+      <button type="button" class="quarto-btn-toggle btn" data-bs-toggle="collapse" role="button" data-bs-target=".quarto-sidebar-collapse-item" aria-controls="quarto-sidebar" aria-expanded="false" aria-label="Toggle sidebar navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
+        <i class="bi bi-layout-text-sidebar-reverse"></i>
+      </button>
+        <nav class="quarto-page-breadcrumbs" aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="../explains/explaining_xt_components.html">Explanations</a></li><li class="breadcrumb-item"><a href="../explains/websockets.html">WebSockets</a></li></ol></nav>
+        <a class="flex-grow-1" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" aria-controls="quarto-sidebar" aria-expanded="false" aria-label="Toggle sidebar navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">      
+        </a>
+    </div>
+  </nav>
+</header>
+<div id="quarto-content" class="quarto-container page-columns page-rows-contents page-layout-article page-navbar">
+  <nav id="quarto-sidebar" class="sidebar collapse collapse-horizontal quarto-sidebar-collapse-item sidebar-navigation floating overflow-auto">
+    <div class="sidebar-menu-container"> 
+    <ul class="list-unstyled mt-1">
+        <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../index.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Get Started</span></a>
+  </div>
+</li>
+        <li class="sidebar-item sidebar-item-section">
+      <div class="sidebar-item-container"> 
+            <a href="../tutorials/index.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Tutorials</span></a>
+          <a class="sidebar-item-toggle text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-1" role="navigation" aria-expanded="true" aria-label="Toggle section">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="quarto-sidebar-section-1" class="collapse list-unstyled sidebar-section depth1 show">  
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../tutorials/by_example.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">FastHTML By Example</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../tutorials/quickstart_for_web_devs.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Web Devs Quickstart</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../tutorials/e2e.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">JS App Walkthrough</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../tutorials/jupyter_and_fasthtml.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Using Jupyter to write FastHTML</span></a>
+  </div>
+</li>
+      </ul>
+  </li>
+        <li class="sidebar-item sidebar-item-section">
+      <div class="sidebar-item-container"> 
+            <a class="sidebar-item-text sidebar-link text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-2" role="navigation" aria-expanded="true">
+ <span class="menu-text">Explanations</span></a>
+          <a class="sidebar-item-toggle text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-2" role="navigation" aria-expanded="true" aria-label="Toggle section">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="quarto-sidebar-section-2" class="collapse list-unstyled sidebar-section depth1 show">  
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/explaining_xt_components.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text"><strong>FT</strong> Components</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/faq.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">FAQ</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/minidataapi.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">MiniDataAPI Spec</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/oauth.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">OAuth</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/routes.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Routes</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/websockets.html" class="sidebar-item-text sidebar-link active">
+ <span class="menu-text">WebSockets</span></a>
+  </div>
+</li>
+      </ul>
+  </li>
+        <li class="sidebar-item sidebar-item-section">
+      <div class="sidebar-item-container"> 
+            <a class="sidebar-item-text sidebar-link text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-3" role="navigation" aria-expanded="true">
+ <span class="menu-text">Reference</span></a>
+          <a class="sidebar-item-toggle text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-3" role="navigation" aria-expanded="true" aria-label="Toggle section">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="quarto-sidebar-section-3" class="collapse list-unstyled sidebar-section depth1 show">  
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../ref/defining_xt_component.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Custom Components</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../ref/handlers.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Handling handlers</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../ref/live_reload.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Live Reloading</span></a>
+  </div>
+</li>
+      </ul>
+  </li>
+        <li class="sidebar-item sidebar-item-section">
+      <div class="sidebar-item-container"> 
+            <a class="sidebar-item-text sidebar-link text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-4" role="navigation" aria-expanded="true">
+ <span class="menu-text">Source</span></a>
+          <a class="sidebar-item-toggle text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-4" role="navigation" aria-expanded="true" aria-label="Toggle section">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="quarto-sidebar-section-4" class="collapse list-unstyled sidebar-section depth1 show">  
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/core.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Core</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/components.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Components</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/xtend.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Component extensions</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/js.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Javascript examples</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/pico.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Pico.css components</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/svg.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">SVG</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/jupyter.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Jupyter compatibility</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/oauth.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">OAuth</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/cli.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Command Line Tools</span></a>
+  </div>
+</li>
+      </ul>
+  </li>
+    </ul>
+    </div>
+</nav>
+<div id="quarto-sidebar-glass" class="quarto-sidebar-collapse-item" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item"></div>
+    <div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
+        <nav id="TOC" role="doc-toc" class="toc-active">
+    <h2 id="toc-title">On this page</h2>
+   
+  <ul>
+  <li><a href="#session-data-in-websockets" id="toc-session-data-in-websockets" class="nav-link active" data-scroll-target="#session-data-in-websockets">Session data in Websockets</a></li>
+  <li><a href="#real-time-chat-app" id="toc-real-time-chat-app" class="nav-link" data-scroll-target="#real-time-chat-app">Real-Time Chat App</a>
+  <ul class="collapse">
+  <li><a href="#a-work-in-progress" id="toc-a-work-in-progress" class="nav-link" data-scroll-target="#a-work-in-progress">A Work in Progress</a></li>
+  </ul></li>
+  </ul>
+<div class="toc-actions"><ul><li><a href="https://github.com/AnswerDotAI/fasthtml/issues/new" class="toc-action"><i class="bi bi-github"></i>Report an issue</a></li></ul></div><div class="quarto-alternate-formats"><h2>Other Formats</h2><ul><li><a href="websockets.html.md"><i class="bi bi-file-code"></i>CommonMark</a></li></ul></div></nav>
+    </div>
+<main class="content" id="quarto-document-content">
+
+<header id="title-block-header" class="quarto-title-block default"><nav class="quarto-page-breadcrumbs quarto-title-breadcrumbs d-none d-lg-block" aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="../explains/explaining_xt_components.html">Explanations</a></li><li class="breadcrumb-item"><a href="../explains/websockets.html">WebSockets</a></li></ol></nav>
+<div class="quarto-title">
+<h1 class="title">WebSockets</h1>
+</div>
+
+
+
+<div class="quarto-title-meta">
+
+    
+  
+    
+  </div>
+  
+
+
+</header>
+
+
+<p>Websockets are a protocol for two-way, persistent communication between a client and server. This is different from HTTP, which uses a request/response model where the client sends a request and the server responds. With websockets, either party can send messages at any time, and the other party can respond.</p>
+<p>This allows for different applications to be built, including things like chat apps, live-updating dashboards, and real-time collaborative tools, which would require constant polling of the server for updates with HTTP.</p>
+<p>In FastHTML, you can create a websocket route using the <code>@app.ws</code> decorator. This decorator takes a route path, and optional <code>conn</code> and <code>disconn</code> parameters representing the <code>on_connect</code> and <code>on_disconnect</code> callbacks in websockets, respectively. The function decorated by <code>@app.ws</code> is the main function that is called when a message is received.</p>
+<p>Here’s an example of a basic websocket route:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="at">@app.ws</span>(<span class="st">'/ws'</span>, conn<span class="op">=</span>on_conn, disconn<span class="op">=</span>on_disconn)</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="cf">async</span> <span class="kw">def</span> on_message(msg:<span class="bu">str</span>, send):</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">await</span> send(Div(<span class="st">'Hello '</span> <span class="op">+</span> msg, <span class="bu">id</span><span class="op">=</span><span class="st">'notifications'</span>))</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">await</span> send(Div(<span class="st">'Goodbye '</span> <span class="op">+</span> msg, <span class="bu">id</span><span class="op">=</span><span class="st">'notifications'</span>))</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>The <code>on_message</code> function is the main function that is called when a message is received and can be named however you like. Similar to standard routes, the arguments to <code>on_message</code> are automatically parsed from the websocket payload for you, so you don’t need to manually parse the message content. However, certain argument names are reserved for special purposes. Here are the most important ones:</p>
+<ul>
+<li><code>send</code> is a function that can be used to send text data to the client.</li>
+<li><code>data</code> is a dictionary containing the data sent by the client.</li>
+<li><code>ws</code> is a reference to the websocket object.</li>
+</ul>
+<p>For example, we can send a message to the client that just connected like this:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="cf">async</span> <span class="kw">def</span> on_conn(send):</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>    <span class="cf">await</span> send(Div(<span class="st">'Hello, world!'</span>))</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>Or if we receive a message from the client, we can send a message back to them:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="at">@app.ws</span>(<span class="st">'/ws'</span>, conn<span class="op">=</span>on_conn, disconn<span class="op">=</span>on_disconn)</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="cf">async</span> <span class="kw">def</span> on_message(msg:<span class="bu">str</span>, send):</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">await</span> send(Div(<span class="st">'You said: '</span> <span class="op">+</span> msg, <span class="bu">id</span><span class="op">=</span><span class="st">'notifications'</span>))</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="co"># or...</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> Div(<span class="st">'You said: '</span> <span class="op">+</span> msg, <span class="bu">id</span><span class="op">=</span><span class="st">'notifications'</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>On the client side, we can use HTMX’s websocket extension to open a websocket connection and send/receive messages. For example:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> fasthtml.common <span class="im">import</span> <span class="op">*</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>app <span class="op">=</span> FastHTML(exts<span class="op">=</span><span class="st">'ws'</span>)</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a><span class="at">@app.get</span>(<span class="st">'/'</span>)</span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> home():</span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>    cts <span class="op">=</span> Div(</span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>        Div(<span class="bu">id</span><span class="op">=</span><span class="st">'notifications'</span>),</span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>        Form(Input(<span class="bu">id</span><span class="op">=</span><span class="st">'msg'</span>), <span class="bu">id</span><span class="op">=</span><span class="st">'form'</span>, ws_send<span class="op">=</span><span class="va">True</span>),</span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>        hx_ext<span class="op">=</span><span class="st">'ws'</span>, ws_connect<span class="op">=</span><span class="st">'/ws'</span>)</span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> Titled(<span class="st">'Websocket Test'</span>, cts)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>This will create a websocket connection to the server on route <code>/ws</code>, and send any form submissions to the server via the websocket. The server will then respond by sending a message back to the client. The client will then update the message div with the message from the server using Out of Band Swaps, which means that the content is swapped with the same id without reloading the page.</p>
+<div class="callout callout-style-default callout-note callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-title-container flex-fill">
+Note
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>Make sure you set <code>exts='ws'</code> when creating your <a href="https://docs.fastht.ml/api/core.html#fasthtml"><code>FastHTML</code></a> object if you want to use websockets so the extension is loaded.</p>
+</div>
+</div>
+<p>Putting it all together, the code for the client and server should look like this:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> fasthtml.common <span class="im">import</span> <span class="op">*</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>app <span class="op">=</span> FastHTML(exts<span class="op">=</span><span class="st">'ws'</span>)</span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>rt <span class="op">=</span> app.route</span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a><span class="at">@rt</span>(<span class="st">'/'</span>)</span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> get():</span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>    cts <span class="op">=</span> Div(</span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>        Div(<span class="bu">id</span><span class="op">=</span><span class="st">'notifications'</span>),</span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>        Form(Input(<span class="bu">id</span><span class="op">=</span><span class="st">'msg'</span>), <span class="bu">id</span><span class="op">=</span><span class="st">'form'</span>, ws_send<span class="op">=</span><span class="va">True</span>),</span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>        hx_ext<span class="op">=</span><span class="st">'ws'</span>, ws_connect<span class="op">=</span><span class="st">'/ws'</span>)</span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> Titled(<span class="st">'Websocket Test'</span>, cts)</span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a><span class="at">@app.ws</span>(<span class="st">'/ws'</span>)</span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a><span class="cf">async</span> <span class="kw">def</span> ws(msg:<span class="bu">str</span>, send):</span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a>    <span class="cf">await</span> send(Div(<span class="st">'Hello '</span> <span class="op">+</span> msg, <span class="bu">id</span><span class="op">=</span><span class="st">'notifications'</span>))</span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a>serve()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>This is a fairly simple example and could be done just as easily with standard HTTP requests, but it illustrates the basic idea of how websockets work. Let’s look at a more complex example next.</p>
+<section id="session-data-in-websockets" class="level2">
+<h2 class="anchored" data-anchor-id="session-data-in-websockets">Session data in Websockets</h2>
+<p>Session data is shared between standard HTTP routes and Websockets. This means you can access, for example, logged in user ID inside websocket handler:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> fasthtml.common <span class="im">import</span> <span class="op">*</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>app <span class="op">=</span> FastHTML(exts<span class="op">=</span><span class="st">'ws'</span>)</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>rt <span class="op">=</span> app.route</span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="at">@rt</span>(<span class="st">'/login'</span>)</span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> get(session):</span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>    session[<span class="st">"person"</span>] <span class="op">=</span> <span class="st">"Bob"</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="st">"ok"</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a><span class="at">@app.ws</span>(<span class="st">'/ws'</span>)</span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a><span class="cf">async</span> <span class="kw">def</span> ws(msg:<span class="bu">str</span>, send, session):</span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>    <span class="cf">await</span> send(Div(<span class="ss">f'Hello </span><span class="sc">{</span>session<span class="sc">.</span>get(<span class="st">"person"</span>)<span class="sc">}</span><span class="ss">'</span> <span class="op">+</span> msg, <span class="bu">id</span><span class="op">=</span><span class="st">'notifications'</span>))</span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>serve()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</section>
+<section id="real-time-chat-app" class="level2">
+<h2 class="anchored" data-anchor-id="real-time-chat-app">Real-Time Chat App</h2>
+<p>Let’s put our new websocket knowledge to use by building a simple chat app. We will create a chat app where multiple users can send and receive messages in real time.</p>
+<p>Let’s start by defining the app and the home page:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> fasthtml.common <span class="im">import</span> <span class="op">*</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>app <span class="op">=</span> FastHTML(exts<span class="op">=</span><span class="st">'ws'</span>)</span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>rt <span class="op">=</span> app.route</span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>msgs <span class="op">=</span> []</span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="at">@rt</span>(<span class="st">'/'</span>)</span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> home(): <span class="cf">return</span> Div(</span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>    Div(Ul(<span class="op">*</span>[Li(m) <span class="cf">for</span> m <span class="kw">in</span> msgs], <span class="bu">id</span><span class="op">=</span><span class="st">'msg-list'</span>)),</span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>    Form(Input(<span class="bu">id</span><span class="op">=</span><span class="st">'msg'</span>), <span class="bu">id</span><span class="op">=</span><span class="st">'form'</span>, ws_send<span class="op">=</span><span class="va">True</span>),</span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>    hx_ext<span class="op">=</span><span class="st">'ws'</span>, ws_connect<span class="op">=</span><span class="st">'/ws'</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>Now, let’s handle the websocket connection. We’ll add a new route for this along with an <code>on_conn</code> and <code>on_disconn</code> function to keep track of the users currently connected to the websocket. Finally, we will handle the logic for sending messages to all connected users.</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>users <span class="op">=</span> {}</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> on_conn(ws, send): users[<span class="bu">str</span>(<span class="bu">id</span>(ws))] <span class="op">=</span> send</span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> on_disconn(ws): users.pop(<span class="bu">str</span>(<span class="bu">id</span>(ws)), <span class="va">None</span>)</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a><span class="at">@app.ws</span>(<span class="st">'/ws'</span>, conn<span class="op">=</span>on_conn, disconn<span class="op">=</span>on_disconn)</span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a><span class="cf">async</span> <span class="kw">def</span> ws(msg:<span class="bu">str</span>):</span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>    msgs.append(msg)</span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>    <span class="co"># Use associated `send` function to send message to each user</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> u <span class="kw">in</span> users.values(): <span class="cf">await</span> u(Ul(<span class="op">*</span>[Li(m) <span class="cf">for</span> m <span class="kw">in</span> msgs], <span class="bu">id</span><span class="op">=</span><span class="st">'msg-list'</span>))</span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>serve()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>We can now run this app with <code>python chat_ws.py</code> and open multiple browser tabs to <code>http://localhost:5001</code>. You should be able to send messages in one tab and see them appear in the other tabs.</p>
+<section id="a-work-in-progress" class="level3">
+<h3 class="anchored" data-anchor-id="a-work-in-progress">A Work in Progress</h3>
+<p>This page (and Websocket support in FastHTML) is a work in progress. Questions, PRs, and feedback are welcome!</p>
+
+
+</section>
+</section>
+
+</main> <!-- /main -->
+<script id="quarto-html-after-body" type="application/javascript">
+window.document.addEventListener("DOMContentLoaded", function (event) {
+  const toggleBodyColorMode = (bsSheetEl) => {
+    const mode = bsSheetEl.getAttribute("data-mode");
+    const bodyEl = window.document.querySelector("body");
+    if (mode === "dark") {
+      bodyEl.classList.add("quarto-dark");
+      bodyEl.classList.remove("quarto-light");
+    } else {
+      bodyEl.classList.add("quarto-light");
+      bodyEl.classList.remove("quarto-dark");
+    }
+  }
+  const toggleBodyColorPrimary = () => {
+    const bsSheetEl = window.document.querySelector("link#quarto-bootstrap");
+    if (bsSheetEl) {
+      toggleBodyColorMode(bsSheetEl);
+    }
+  }
+  toggleBodyColorPrimary();  
+  const icon = "";
+  const anchorJS = new window.AnchorJS();
+  anchorJS.options = {
+    placement: 'right',
+    icon: icon
+  };
+  anchorJS.add('.anchored');
+  const isCodeAnnotation = (el) => {
+    for (const clz of el.classList) {
+      if (clz.startsWith('code-annotation-')) {                     
+        return true;
+      }
+    }
+    return false;
+  }
+  const onCopySuccess = function(e) {
+    // button target
+    const button = e.trigger;
+    // don't keep focus
+    button.blur();
+    // flash "checked"
+    button.classList.add('code-copy-button-checked');
+    var currentTitle = button.getAttribute("title");
+    button.setAttribute("title", "Copied!");
+    let tooltip;
+    if (window.bootstrap) {
+      button.setAttribute("data-bs-toggle", "tooltip");
+      button.setAttribute("data-bs-placement", "left");
+      button.setAttribute("data-bs-title", "Copied!");
+      tooltip = new bootstrap.Tooltip(button, 
+        { trigger: "manual", 
+          customClass: "code-copy-button-tooltip",
+          offset: [0, -8]});
+      tooltip.show();    
+    }
+    setTimeout(function() {
+      if (tooltip) {
+        tooltip.hide();
+        button.removeAttribute("data-bs-title");
+        button.removeAttribute("data-bs-toggle");
+        button.removeAttribute("data-bs-placement");
+      }
+      button.setAttribute("title", currentTitle);
+      button.classList.remove('code-copy-button-checked');
+    }, 1000);
+    // clear code selection
+    e.clearSelection();
+  }
+  const getTextToCopy = function(trigger) {
+      const codeEl = trigger.previousElementSibling.cloneNode(true);
+      for (const childEl of codeEl.children) {
+        if (isCodeAnnotation(childEl)) {
+          childEl.remove();
+        }
+      }
+      return codeEl.innerText;
+  }
+  const clipboard = new window.ClipboardJS('.code-copy-button:not([data-in-quarto-modal])', {
+    text: getTextToCopy
+  });
+  clipboard.on('success', onCopySuccess);
+  if (window.document.getElementById('quarto-embedded-source-code-modal')) {
+    const clipboardModal = new window.ClipboardJS('.code-copy-button[data-in-quarto-modal]', {
+      text: getTextToCopy,
+      container: window.document.getElementById('quarto-embedded-source-code-modal')
+    });
+    clipboardModal.on('success', onCopySuccess);
+  }
+    var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
+    var mailtoRegex = new RegExp(/^mailto:/);
+      var filterRegex = new RegExp("https:\/\/docs\.fastht\.ml\/");
+    var isInternal = (href) => {
+        return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
+    }
+    // Inspect non-navigation links and adorn them if external
+ 	var links = window.document.querySelectorAll('a[href]:not(.nav-link):not(.navbar-brand):not(.toc-action):not(.sidebar-link):not(.sidebar-item-toggle):not(.pagination-link):not(.no-external):not([aria-hidden]):not(.dropdown-item):not(.quarto-navigation-tool):not(.about-link)');
+    for (var i=0; i<links.length; i++) {
+      const link = links[i];
+      if (!isInternal(link.href)) {
+        // undo the damage that might have been done by quarto-nav.js in the case of
+        // links that we want to consider external
+        if (link.dataset.originalHref !== undefined) {
+          link.href = link.dataset.originalHref;
+        }
+      }
+    }
+  function tippyHover(el, contentFn, onTriggerFn, onUntriggerFn) {
+    const config = {
+      allowHTML: true,
+      maxWidth: 500,
+      delay: 100,
+      arrow: false,
+      appendTo: function(el) {
+          return el.parentElement;
+      },
+      interactive: true,
+      interactiveBorder: 10,
+      theme: 'quarto',
+      placement: 'bottom-start',
+    };
+    if (contentFn) {
+      config.content = contentFn;
+    }
+    if (onTriggerFn) {
+      config.onTrigger = onTriggerFn;
+    }
+    if (onUntriggerFn) {
+      config.onUntrigger = onUntriggerFn;
+    }
+    window.tippy(el, config); 
+  }
+  const noterefs = window.document.querySelectorAll('a[role="doc-noteref"]');
+  for (var i=0; i<noterefs.length; i++) {
+    const ref = noterefs[i];
+    tippyHover(ref, function() {
+      // use id or data attribute instead here
+      let href = ref.getAttribute('data-footnote-href') || ref.getAttribute('href');
+      try { href = new URL(href).hash; } catch {}
+      const id = href.replace(/^#\/?/, "");
+      const note = window.document.getElementById(id);
+      if (note) {
+        return note.innerHTML;
+      } else {
+        return "";
+      }
+    });
+  }
+  const xrefs = window.document.querySelectorAll('a.quarto-xref');
+  const processXRef = (id, note) => {
+    // Strip column container classes
+    const stripColumnClz = (el) => {
+      el.classList.remove("page-full", "page-columns");
+      if (el.children) {
+        for (const child of el.children) {
+          stripColumnClz(child);
+        }
+      }
+    }
+    stripColumnClz(note)
+    if (id === null || id.startsWith('sec-')) {
+      // Special case sections, only their first couple elements
+      const container = document.createElement("div");
+      if (note.children && note.children.length > 2) {
+        container.appendChild(note.children[0].cloneNode(true));
+        for (let i = 1; i < note.children.length; i++) {
+          const child = note.children[i];
+          if (child.tagName === "P" && child.innerText === "") {
+            continue;
+          } else {
+            container.appendChild(child.cloneNode(true));
+            break;
+          }
+        }
+        if (window.Quarto?.typesetMath) {
+          window.Quarto.typesetMath(container);
+        }
+        return container.innerHTML
+      } else {
+        if (window.Quarto?.typesetMath) {
+          window.Quarto.typesetMath(note);
+        }
+        return note.innerHTML;
+      }
+    } else {
+      // Remove any anchor links if they are present
+      const anchorLink = note.querySelector('a.anchorjs-link');
+      if (anchorLink) {
+        anchorLink.remove();
+      }
+      if (window.Quarto?.typesetMath) {
+        window.Quarto.typesetMath(note);
+      }
+      if (note.classList.contains("callout")) {
+        return note.outerHTML;
+      } else {
+        return note.innerHTML;
+      }
+    }
+  }
+  for (var i=0; i<xrefs.length; i++) {
+    const xref = xrefs[i];
+    tippyHover(xref, undefined, function(instance) {
+      instance.disable();
+      let url = xref.getAttribute('href');
+      let hash = undefined; 
+      if (url.startsWith('#')) {
+        hash = url;
+      } else {
+        try { hash = new URL(url).hash; } catch {}
+      }
+      if (hash) {
+        const id = hash.replace(/^#\/?/, "");
+        const note = window.document.getElementById(id);
+        if (note !== null) {
+          try {
+            const html = processXRef(id, note.cloneNode(true));
+            instance.setContent(html);
+          } finally {
+            instance.enable();
+            instance.show();
+          }
+        } else {
+          // See if we can fetch this
+          fetch(url.split('#')[0])
+          .then(res => res.text())
+          .then(html => {
+            const parser = new DOMParser();
+            const htmlDoc = parser.parseFromString(html, "text/html");
+            const note = htmlDoc.getElementById(id);
+            if (note !== null) {
+              const html = processXRef(id, note);
+              instance.setContent(html);
+            } 
+          }).finally(() => {
+            instance.enable();
+            instance.show();
+          });
+        }
+      } else {
+        // See if we can fetch a full url (with no hash to target)
+        // This is a special case and we should probably do some content thinning / targeting
+        fetch(url)
+        .then(res => res.text())
+        .then(html => {
+          const parser = new DOMParser();
+          const htmlDoc = parser.parseFromString(html, "text/html");
+          const note = htmlDoc.querySelector('main.content');
+          if (note !== null) {
+            // This should only happen for chapter cross references
+            // (since there is no id in the URL)
+            // remove the first header
+            if (note.children.length > 0 && note.children[0].tagName === "HEADER") {
+              note.children[0].remove();
+            }
+            const html = processXRef(null, note);
+            instance.setContent(html);
+          } 
+        }).finally(() => {
+          instance.enable();
+          instance.show();
+        });
+      }
+    }, function(instance) {
+    });
+  }
+      let selectedAnnoteEl;
+      const selectorForAnnotation = ( cell, annotation) => {
+        let cellAttr = 'data-code-cell="' + cell + '"';
+        let lineAttr = 'data-code-annotation="' +  annotation + '"';
+        const selector = 'span[' + cellAttr + '][' + lineAttr + ']';
+        return selector;
+      }
+      const selectCodeLines = (annoteEl) => {
+        const doc = window.document;
+        const targetCell = annoteEl.getAttribute("data-target-cell");
+        const targetAnnotation = annoteEl.getAttribute("data-target-annotation");
+        const annoteSpan = window.document.querySelector(selectorForAnnotation(targetCell, targetAnnotation));
+        const lines = annoteSpan.getAttribute("data-code-lines").split(",");
+        const lineIds = lines.map((line) => {
+          return targetCell + "-" + line;
+        })
+        let top = null;
+        let height = null;
+        let parent = null;
+        if (lineIds.length > 0) {
+            //compute the position of the single el (top and bottom and make a div)
+            const el = window.document.getElementById(lineIds[0]);
+            top = el.offsetTop;
+            height = el.offsetHeight;
+            parent = el.parentElement.parentElement;
+          if (lineIds.length > 1) {
+            const lastEl = window.document.getElementById(lineIds[lineIds.length - 1]);
+            const bottom = lastEl.offsetTop + lastEl.offsetHeight;
+            height = bottom - top;
+          }
+          if (top !== null && height !== null && parent !== null) {
+            // cook up a div (if necessary) and position it 
+            let div = window.document.getElementById("code-annotation-line-highlight");
+            if (div === null) {
+              div = window.document.createElement("div");
+              div.setAttribute("id", "code-annotation-line-highlight");
+              div.style.position = 'absolute';
+              parent.appendChild(div);
+            }
+            div.style.top = top - 2 + "px";
+            div.style.height = height + 4 + "px";
+            div.style.left = 0;
+            let gutterDiv = window.document.getElementById("code-annotation-line-highlight-gutter");
+            if (gutterDiv === null) {
+              gutterDiv = window.document.createElement("div");
+              gutterDiv.setAttribute("id", "code-annotation-line-highlight-gutter");
+              gutterDiv.style.position = 'absolute';
+              const codeCell = window.document.getElementById(targetCell);
+              const gutter = codeCell.querySelector('.code-annotation-gutter');
+              gutter.appendChild(gutterDiv);
+            }
+            gutterDiv.style.top = top - 2 + "px";
+            gutterDiv.style.height = height + 4 + "px";
+          }
+          selectedAnnoteEl = annoteEl;
+        }
+      };
+      const unselectCodeLines = () => {
+        const elementsIds = ["code-annotation-line-highlight", "code-annotation-line-highlight-gutter"];
+        elementsIds.forEach((elId) => {
+          const div = window.document.getElementById(elId);
+          if (div) {
+            div.remove();
+          }
+        });
+        selectedAnnoteEl = undefined;
+      };
+        // Handle positioning of the toggle
+    window.addEventListener(
+      "resize",
+      throttle(() => {
+        elRect = undefined;
+        if (selectedAnnoteEl) {
+          selectCodeLines(selectedAnnoteEl);
+        }
+      }, 10)
+    );
+    function throttle(fn, ms) {
+    let throttle = false;
+    let timer;
+      return (...args) => {
+        if(!throttle) { // first call gets through
+            fn.apply(this, args);
+            throttle = true;
+        } else { // all the others get throttled
+            if(timer) clearTimeout(timer); // cancel #2
+            timer = setTimeout(() => {
+              fn.apply(this, args);
+              timer = throttle = false;
+            }, ms);
+        }
+      };
+    }
+      // Attach click handler to the DT
+      const annoteDls = window.document.querySelectorAll('dt[data-target-cell]');
+      for (const annoteDlNode of annoteDls) {
+        annoteDlNode.addEventListener('click', (event) => {
+          const clickedEl = event.target;
+          if (clickedEl !== selectedAnnoteEl) {
+            unselectCodeLines();
+            const activeEl = window.document.querySelector('dt[data-target-cell].code-annotation-active');
+            if (activeEl) {
+              activeEl.classList.remove('code-annotation-active');
+            }
+            selectCodeLines(clickedEl);
+            clickedEl.classList.add('code-annotation-active');
+          } else {
+            // Unselect the line
+            unselectCodeLines();
+            clickedEl.classList.remove('code-annotation-active');
+          }
+        });
+      }
+  const findCites = (el) => {
+    const parentEl = el.parentElement;
+    if (parentEl) {
+      const cites = parentEl.dataset.cites;
+      if (cites) {
+        return {
+          el,
+          cites: cites.split(' ')
+        };
+      } else {
+        return findCites(el.parentElement)
+      }
+    } else {
+      return undefined;
+    }
+  };
+  var bibliorefs = window.document.querySelectorAll('a[role="doc-biblioref"]');
+  for (var i=0; i<bibliorefs.length; i++) {
+    const ref = bibliorefs[i];
+    const citeInfo = findCites(ref);
+    if (citeInfo) {
+      tippyHover(citeInfo.el, function() {
+        var popup = window.document.createElement('div');
+        citeInfo.cites.forEach(function(cite) {
+          var citeDiv = window.document.createElement('div');
+          citeDiv.classList.add('hanging-indent');
+          citeDiv.classList.add('csl-entry');
+          var biblioDiv = window.document.getElementById('ref-' + cite);
+          if (biblioDiv) {
+            citeDiv.innerHTML = biblioDiv.innerHTML;
+          }
+          popup.appendChild(citeDiv);
+        });
+        return popup.innerHTML;
+      });
+    }
+  }
+});
+</script>
+</div> <!-- /content -->
+
+
+
+
+<footer class="footer"><div class="nav-footer"><div class="nav-footer-center"><div class="toc-actions d-sm-block d-md-none"><ul><li><a href="https://github.com/AnswerDotAI/fasthtml/issues/new" class="toc-action"><i class="bi bi-github"></i>Report an issue</a></li></ul></div></div></div></footer></body></html></doc><doc title="Custom Components" desc="Explanation of how to create custom components in FastHTML."><!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'self'">
+    <title>Page not found &middot; GitHub Pages</title>
+    <style type="text/css" media="screen">
+      body {
+        background-color: #f1f1f1;
+        margin: 0;
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      }
+
+      .container { margin: 50px auto 40px auto; width: 600px; text-align: center; }
+
+      a { color: #4183c4; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+
+      h1 { width: 800px; position:relative; left: -100px; letter-spacing: -1px; line-height: 60px; font-size: 60px; font-weight: 100; margin: 0px 0 50px 0; text-shadow: 0 1px 0 #fff; }
+      p { color: rgba(0, 0, 0, 0.5); margin: 20px 0; line-height: 1.6; }
+
+      ul { list-style: none; margin: 25px 0; padding: 0; }
+      li { display: table-cell; font-weight: bold; width: 1%; }
+
+      .logo { display: inline-block; margin-top: 35px; }
+      .logo-img-2x { display: none; }
+      @media
+      only screen and (-webkit-min-device-pixel-ratio: 2),
+      only screen and (   min--moz-device-pixel-ratio: 2),
+      only screen and (     -o-min-device-pixel-ratio: 2/1),
+      only screen and (        min-device-pixel-ratio: 2),
+      only screen and (                min-resolution: 192dpi),
+      only screen and (                min-resolution: 2dppx) {
+        .logo-img-1x { display: none; }
+        .logo-img-2x { display: inline-block; }
+      }
+
+      #suggestions {
+        margin-top: 35px;
+        color: #ccc;
+      }
+      #suggestions a {
+        color: #666666;
+        font-weight: 200;
+        font-size: 14px;
+        margin: 0 10px;
+      }
+
+    </style>
+  </head>
+  <body>
+
+    <div class="container">
+
+      <h1>404</h1>
+      <p><strong>File not found</strong></p>
+
+      <p>
+        The site configured at this address does not
+        contain the requested file.
+      </p>
+
+      <p>
+        If this is your site, make sure that the filename case matches the URL
+        as well as any file permissions.<br>
+        For root URLs (like <code>http://example.com/</code>) you must provide an
+        <code>index.html</code> file.
+      </p>
+
+      <p>
+        <a href="https://help.github.com/pages/">Read the full documentation</a>
+        for more information about using <strong>GitHub Pages</strong>.
+      </p>
+
+      <div id="suggestions">
+        <a href="https://githubstatus.com">GitHub Status</a> &mdash;
+        <a href="https://twitter.com/githubstatus">@githubstatus</a>
+      </div>
+
+      <a href="/" class="logo logo-img-1x">
+      </a>
+
+      <a href="/" class="logo logo-img-2x">
+      </a>
+    </div>
+  </body>
+</html></doc><doc title="Handling Handlers" desc="Explanation of how to request and response handlers work in FastHTML as routes."># Handling handlers
+
+
+
+``` python
+from fasthtml.common import *
+from collections import namedtuple
+from typing import TypedDict
+from datetime import datetime
+import json,time
+```
+
+``` python
+app = FastHTML()
+```
+
+The [`FastHTML`](https://docs.fastht.ml/api/core.html#fasthtml) class is
+the main application class for FastHTML apps.
+
+``` python
+rt = app.route
+```
+
+`app.route` is used to register route handlers. It is a decorator, which
+means we place it before a function that is used as a handler. Because
+it’s used frequently in most FastHTML applications, we often alias it as
+`rt`, as we do here.
+
+## Basic Route Handling
+
+``` python
+@rt("/hi")
+def get(): return 'Hi there'
+```
+
+Handler functions can return strings directly. These strings are sent as
+the response body to the client.
+
+``` python
+cli = Client(app)
+```
+
+[`Client`](https://docs.fastht.ml/api/core.html#client) is a test client
+for FastHTML applications. It allows you to simulate requests to your
+app without running a server.
+
+``` python
+cli.get('/hi').text
+```
+
+    'Hi there'
+
+The `get` method on a
+[`Client`](https://docs.fastht.ml/api/core.html#client) instance
+simulates GET requests to the app. It returns a response object that has
+a `.text` attribute, which you can use to access the body of the
+response. It calls `httpx.get` internally – all httpx HTTP verbs are
+supported.
+
+``` python
+@rt("/hi")
+def post(): return 'Postal'
+cli.post('/hi').text
+```
+
+    'Postal'
+
+Handler functions can be defined for different HTTP methods on the same
+route. Here, we define a `post` handler for the `/hi` route. The
+[`Client`](https://docs.fastht.ml/api/core.html#client) instance can
+simulate different HTTP methods, including POST requests.
+
+## Request and Response Objects
+
+``` python
+@app.get("/hostie")
+def show_host(req): return req.headers['host']
+cli.get('/hostie').text
+```
+
+    'testserver'
+
+Handler functions can accept a `req` (or `request`) parameter, which
+represents the incoming request. This object contains information about
+the request, including headers. In this example, we return the `host`
+header from the request. The test client uses ‘testserver’ as the
+default host.
+
+In this example, we use `@app.get("/hostie")` instead of
+`@rt("/hostie")`. The `@app.get()` decorator explicitly specifies the
+HTTP method (GET) for the route, while `@rt()` by default handles both
+GET and POST requests.
+
+``` python
+@rt
+def yoyo(): return 'a yoyo'
+cli.post('/yoyo').text
+```
+
+    'a yoyo'
+
+If the `@rt` decorator is used without arguments, it uses the function
+name as the route path. Here, the `yoyo` function becomes the handler
+for the `/yoyo` route. This handler responds to GET and POST methods,
+since a specific method wasn’t provided.
+
+``` python
+@rt
+def ft1(): return Html(Div('Text.'))
+print(cli.get('/ft1').text)
+```
+
+     <!doctype html>
+     <html>
+       <div>Text.</div>
+     </html>
+
+Handler functions can return
+[`FT`](https://docs.fastht.ml/explains/explaining_xt_components.html)
+objects, which are automatically converted to HTML strings. The `FT`
+class can take other `FT` components as arguments, such as `Div`. This
+allows for easy composition of HTML elements in your responses.
+
+``` python
+@app.get
+def autopost(): return Html(Div('Text.', hx_post=yoyo.to()))
+print(cli.get('/autopost').text)
+```
+
+     <!doctype html>
+     <html>
+       <div hx-post="/yoyo">Text.</div>
+     </html>
+
+The `rt` decorator modifies the `yoyo` function by adding an `rt()`
+method. This method returns the route path associated with the handler.
+It’s a convenient way to reference the route of a handler function
+dynamically.
+
+In the example, `yoyo.to()` is used as the value for `hx_post`. This
+means when the div is clicked, it will trigger an HTMX POST request to
+the route of the `yoyo` handler. This approach allows for flexible, DRY
+code by avoiding hardcoded route strings and automatically updating if
+the route changes.
+
+This pattern is particularly useful in larger applications where routes
+might change, or when building reusable components that need to
+reference their own routes dynamically.
+
+``` python
+@app.get
+def autoget(): return Html(Body(Div('Text.', cls='px-2', hx_post=show_host.to(a='b'))))
+print(cli.get('/autoget').text)
+```
+
+     <!doctype html>
+     <html>
+       <body>
+         <div hx-post="/hostie?a=b" class="px-2">Text.</div>
+       </body>
+     </html>
+
+The `rt()` method of handler functions can also accept parameters. When
+called with parameters, it returns the route path with a query string
+appended. In this example, `show_host.to(a='b')` generates the path
+`/hostie?a=b`.
+
+The `Body` component is used here to demonstrate nesting of FT
+components. `Div` is nested inside `Body`, showcasing how you can create
+more complex HTML structures.
+
+The `cls` parameter is used to add a CSS class to the `Div`. This
+translates to the `class` attribute in the rendered HTML. (`class` can’t
+be used as a parameter name directly in Python since it’s a reserved
+word.)
+
+``` python
+@rt('/ft2')
+def get(): return Title('Foo'),H1('bar')
+print(cli.get('/ft2').text)
+```
+
+     <!doctype html>
+     <html>
+       <head>
+         <title>Foo</title>
+         <meta charset="utf-8">
+         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script><script src="https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js"></script><script src="https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js"></script><script src="https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js"></script><script>
+        function sendmsg() {
+            window.parent.postMessage({height: document.documentElement.offsetHeight}, '*');
+        }
+        window.onload = function() {
+            sendmsg();
+            document.body.addEventListener('htmx:afterSettle',    sendmsg);
+            document.body.addEventListener('htmx:wsAfterMessage', sendmsg);
+        };</script>   </head>
+       <body>
+         <h1>bar</h1>
+       </body>
+     </html>
+
+Handler functions can return multiple `FT` objects as a tuple. The first
+item is treated as the `Title`, and the rest are added to the `Body`.
+When the request is not an HTMX request, FastHTML automatically adds
+necessary HTML boilerplate, including default `head` content with
+required scripts.
+
+When using `app.route` (or `rt`), if the function name matches an HTTP
+verb (e.g., `get`, `post`, `put`, `delete`), that HTTP method is
+automatically used for the route. In this case, a path must be
+explicitly provided as an argument to the decorator.
+
+``` python
+hxhdr = {'headers':{'hx-request':"1"}}
+print(cli.get('/ft2', **hxhdr).text)
+```
+
+     <title>Foo</title>
+     <h1>bar</h1>
+
+For HTMX requests (indicated by the `hx-request` header), FastHTML
+returns only the specified components without the full HTML structure.
+This allows for efficient partial page updates in HTMX applications.
+
+``` python
+@rt('/ft3')
+def get(): return H1('bar')
+print(cli.get('/ft3', **hxhdr).text)
+```
+
+     <h1>bar</h1>
+
+When a handler function returns a single `FT` object for an HTMX
+request, it’s rendered as a single HTML partial.
+
+``` python
+@rt('/ft4')
+def get(): return Html(Head(Title('hi')), Body(P('there')))
+
+print(cli.get('/ft4').text)
+```
+
+     <!doctype html>
+     <html>
+       <head>
+         <title>hi</title>
+       </head>
+       <body>
+         <p>there</p>
+       </body>
+     </html>
+
+Handler functions can return a complete `Html` structure, including
+`Head` and `Body` components. When a full HTML structure is returned,
+FastHTML doesn’t add any additional boilerplate. This gives you full
+control over the HTML output when needed.
+
+``` python
+@rt
+def index(): return "welcome!"
+print(cli.get('/').text)
+```
+
+    welcome!
+
+The `index` function is a special handler in FastHTML. When defined
+without arguments to the `@rt` decorator, it automatically becomes the
+handler for the root path (`'/'`). This is a convenient way to define
+the main page or entry point of your application.
+
+## Path and Query Parameters
+
+``` python
+@rt('/user/{nm}', name='gday')
+def get(nm:str=''): return f"Good day to you, {nm}!"
+cli.get('/user/Alexis').text
+```
+
+    'Good day to you, Alexis!'
+
+Handler functions can use path parameters, defined using curly braces in
+the route – this is implemented by Starlette directly, so all Starlette
+path parameters can be used. These parameters are passed as arguments to
+the function.
+
+The `name` parameter in the decorator allows you to give the route a
+name, which can be used for URL generation.
+
+In this example, `{nm}` in the route becomes the `nm` parameter in the
+function. The function uses this parameter to create a personalized
+greeting.
+
+``` python
+@app.get
+def autolink(): return Html(Div('Text.', link=uri('gday', nm='Alexis')))
+print(cli.get('/autolink').text)
+```
+
+     <!doctype html>
+     <html>
+       <div href="/user/Alexis">Text.</div>
+     </html>
+
+The [`uri`](https://docs.fastht.ml/api/core.html#uri) function is used
+to generate URLs for named routes. It takes the route name as its first
+argument, followed by any path or query parameters needed for that
+route.
+
+In this example, `uri('gday', nm='Alexis')` generates the URL for the
+route named ‘gday’ (which we defined earlier as ‘/user/{nm}’), with
+‘Alexis’ as the value for the ‘nm’ parameter.
+
+The `link` parameter in FT components sets the `href` attribute of the
+rendered HTML element. By using
+[`uri()`](https://docs.fastht.ml/api/core.html#uri), we can dynamically
+generate correct URLs even if the underlying route structure changes.
+
+This approach promotes maintainable code by centralizing route
+definitions and avoiding hardcoded URLs throughout the application.
+
+``` python
+@rt('/link')
+def get(req): return f"{req.url_for('gday', nm='Alexis')}; {req.url_for('show_host')}"
+
+cli.get('/link').text
+```
+
+    'http://testserver/user/Alexis; http://testserver/hostie'
+
+The `url_for` method of the request object can be used to generate URLs
+for named routes. It takes the route name as its first argument,
+followed by any path parameters needed for that route.
+
+In this example, `req.url_for('gday', nm='Alexis')` generates the full
+URL for the route named ‘gday’, including the scheme and host.
+Similarly, `req.url_for('show_host')` generates the URL for the
+‘show_host’ route.
+
+This method is particularly useful when you need to generate absolute
+URLs, such as for email links or API responses. It ensures that the
+correct host and scheme are included, even if the application is
+accessed through different domains or protocols.
+
+``` python
+app.url_path_for('gday', nm='Jeremy')
+```
+
+    '/user/Jeremy'
+
+The `url_path_for` method of the application can be used to generate URL
+paths for named routes. Unlike `url_for`, it returns only the path
+component of the URL, without the scheme or host.
+
+In this example, `app.url_path_for('gday', nm='Jeremy')` generates the
+path ‘/user/Jeremy’ for the route named ‘gday’.
+
+This method is useful when you need relative URLs or just the path
+component, such as for internal links or when constructing URLs in a
+host-agnostic manner.
+
+``` python
+@rt('/oops')
+def get(nope): return nope
+r = cli.get('/oops?nope=1')
+print(r)
+r.text
+```
+
+    <Response [200 OK]>
+
+    /Users/iflath/git/AnswerDotAI/fasthtml/build/__editable__.python_fasthtml-0.12.1-py3-none-any/fasthtml/core.py:188: UserWarning: `nope has no type annotation and is not a recognised special name, so is ignored.
+      if arg!='resp': warn(f"`{arg} has no type annotation and is not a recognised special name, so is ignored.")
+
+    ''
+
+Handler functions can include parameters, but they must be
+type-annotated or have special names (like `req`) to be recognized. In
+this example, the `nope` parameter is not annotated, so it’s ignored,
+resulting in a warning.
+
+When a parameter is ignored, it doesn’t receive the value from the query
+string. This can lead to unexpected behavior, as the function attempts
+to return `nope`, which is undefined.
+
+The `cli.get('/oops?nope=1')` call succeeds with a 200 OK status because
+the handler doesn’t raise an exception, but it returns an empty
+response, rather than the intended value.
+
+To fix this, you should either add a type annotation to the parameter
+(e.g., `def get(nope: str):`) or use a recognized special name like
+`req`.
+
+``` python
+@rt('/html/{idx}')
+def get(idx:int): return Body(H4(f'Next is {idx+1}.'))
+print(cli.get('/html/1', **hxhdr).text)
+```
+
+     <body>
+       <h4>Next is 2.</h4>
+     </body>
+
+Path parameters can be type-annotated, and FastHTML will automatically
+convert them to the specified type if possible. In this example, `idx`
+is annotated as `int`, so it’s converted from the string in the URL to
+an integer.
+
+``` python
+reg_re_param("imgext", "ico|gif|jpg|jpeg|webm")
+
+@rt(r'/static/{path:path}{fn}.{ext:imgext}')
+def get(fn:str, path:str, ext:str): return f"Getting {fn}.{ext} from /{path}"
+
+print(cli.get('/static/foo/jph.ico').text)
+```
+
+    Getting jph.ico from /foo/
+
+The [`reg_re_param`](https://docs.fastht.ml/api/core.html#reg_re_param)
+function is used to register custom path parameter types using regular
+expressions. Here, we define a new path parameter type called “imgext”
+that matches common image file extensions.
+
+Handler functions can use complex path patterns with multiple parameters
+and custom types. In this example, the route pattern
+`r'/static/{path:path}{fn}.{ext:imgext}'` uses three path parameters:
+
+1.  `path`: A Starlette built-in type that matches any path segments
+2.  `fn`: The filename without extension
+3.  `ext`: Our custom “imgext” type that matches specific image
+    extensions
+
+``` python
+ModelName = str_enum('ModelName', "alexnet", "resnet", "lenet")
+
+@rt("/models/{nm}")
+def get(nm:ModelName): return nm
+
+print(cli.get('/models/alexnet').text)
+```
+
+    alexnet
+
+We define `ModelName` as an enum with three possible values: “alexnet”,
+“resnet”, and “lenet”. Handler functions can use these enum types as
+parameter annotations. In this example, the `nm` parameter is annotated
+with `ModelName`, which ensures that only valid model names are
+accepted.
+
+When a request is made with a valid model name, the handler function
+returns that name. This pattern is useful for creating type-safe APIs
+with a predefined set of valid values.
+
+``` python
+@rt("/files/{path}")
+async def get(path: Path): return path.with_suffix('.txt')
+print(cli.get('/files/foo').text)
+```
+
+    foo.txt
+
+Handler functions can use
+[`Path`](https://docs.fastht.ml/api/svg.html#path) objects as parameter
+types. The [`Path`](https://docs.fastht.ml/api/svg.html#path) type is
+from Python’s standard library `pathlib` module, which provides an
+object-oriented interface for working with file paths. In this example,
+the `path` parameter is annotated with
+[`Path`](https://docs.fastht.ml/api/svg.html#path), so FastHTML
+automatically converts the string from the URL to a
+[`Path`](https://docs.fastht.ml/api/svg.html#path) object.
+
+This approach is particularly useful when working with file-related
+routes, as it provides a convenient and platform-independent way to
+handle file paths.
+
+``` python
+fake_db = [{"name": "Foo"}, {"name": "Bar"}]
+
+@rt("/items/")
+def get(idx:int|None = 0): return fake_db[idx]
+print(cli.get('/items/?idx=1').text)
+```
+
+    {"name":"Bar"}
+
+Handler functions can use query parameters, which are automatically
+parsed from the URL. In this example, `idx` is a query parameter with a
+default value of 0. It’s annotated as `int|None`, allowing it to be
+either an integer or None.
+
+The function uses this parameter to index into a fake database
+(`fake_db`). When a request is made with a valid `idx` query parameter,
+the handler returns the corresponding item from the database.
+
+``` python
+print(cli.get('/items/').text)
+```
+
+    {"name":"Foo"}
+
+When no `idx` query parameter is provided, the handler function uses the
+default value of 0. This results in returning the first item from the
+`fake_db` list, which is `{"name":"Foo"}`.
+
+This behavior demonstrates how default values for query parameters work
+in FastHTML. They allow the API to have a sensible default behavior when
+optional parameters are not provided.
+
+``` python
+print(cli.get('/items/?idx=g'))
+```
+
+    <Response [404 Not Found]>
+
+When an invalid value is provided for a typed query parameter, FastHTML
+returns a 404 Not Found response. In this example, ‘g’ is not a valid
+integer for the `idx` parameter, so the request fails with a 404 status.
+
+This behavior ensures type safety and prevents invalid inputs from
+reaching the handler function.
+
+``` python
+@app.get("/booly/")
+def _(coming:bool=True): return 'Coming' if coming else 'Not coming'
+print(cli.get('/booly/?coming=true').text)
+print(cli.get('/booly/?coming=no').text)
+```
+
+    Coming
+    Not coming
+
+Handler functions can use boolean query parameters. In this example,
+`coming` is a boolean parameter with a default value of `True`. FastHTML
+automatically converts string values like ‘true’, ‘false’, ‘1’, ‘0’,
+‘on’, ‘off’, ‘yes’, and ‘no’ to their corresponding boolean values.
+
+The underscore `_` is used as the function name in this example to
+indicate that the function’s name is not important or won’t be
+referenced elsewhere. This is a common Python convention for throwaway
+or unused variables, and it works here because FastHTML uses the route
+decorator parameter, when provided, to determine the URL path, not the
+function name. By default, both `get` and `post` methods can be used in
+routes that don’t specify an http method (by either using `app.get`,
+`def get`, or the `methods` parameter to `app.route`).
+
+``` python
+@app.get("/datie/")
+def _(d:parsed_date): return d
+date_str = "17th of May, 2024, 2p"
+print(cli.get(f'/datie/?d={date_str}').text)
+```
+
+    2024-05-17 14:00:00
+
+Handler functions can use `date` objects as parameter types. FastHTML
+uses `dateutil.parser` library to automatically parse a wide variety of
+date string formats into `date` objects.
+
+``` python
+@app.get("/ua")
+async def _(user_agent:str): return user_agent
+print(cli.get('/ua', headers={'User-Agent':'FastHTML'}).text)
+```
+
+    FastHTML
+
+Handler functions can access HTTP headers by using parameter names that
+match the header names. In this example, `user_agent` is used as a
+parameter name, which automatically captures the value of the
+‘User-Agent’ header from the request.
+
+The [`Client`](https://docs.fastht.ml/api/core.html#client) instance
+allows setting custom headers for test requests. Here, we set the
+‘User-Agent’ header to ‘FastHTML’ in the test request.
+
+``` python
+@app.get("/hxtest")
+def _(htmx): return htmx.request
+print(cli.get('/hxtest', headers={'HX-Request':'1'}).text)
+
+@app.get("/hxtest2")
+def _(foo:HtmxHeaders, req): return foo.request
+print(cli.get('/hxtest2', headers={'HX-Request':'1'}).text)
+```
+
+    1
+    1
+
+Handler functions can access HTMX-specific headers using either the
+special `htmx` parameter name, or a parameter annotated with
+[`HtmxHeaders`](https://docs.fastht.ml/api/core.html#htmxheaders). Both
+approaches provide access to HTMX-related information.
+
+In these examples, the `htmx.request` attribute returns the value of the
+‘HX-Request’ header.
+
+``` python
+app.chk = 'foo'
+@app.get("/app")
+def _(app): return app.chk
+print(cli.get('/app').text)
+```
+
+    foo
+
+Handler functions can access the
+[`FastHTML`](https://docs.fastht.ml/api/core.html#fasthtml) application
+instance using the special `app` parameter name. This allows handlers to
+access application-level attributes and methods.
+
+In this example, we set a custom attribute `chk` on the application
+instance. The handler function then uses the `app` parameter to access
+this attribute and return its value.
+
+``` python
+@app.get("/app2")
+def _(foo:FastHTML): return foo.chk,HttpHeader("mykey", "myval")
+r = cli.get('/app2', **hxhdr)
+print(r.text)
+print(r.headers)
+```
+
+    foo
+    Headers({'mykey': 'myval', 'content-length': '3', 'content-type': 'text/html; charset=utf-8'})
+
+Handler functions can access the
+[`FastHTML`](https://docs.fastht.ml/api/core.html#fasthtml) application
+instance using a parameter annotated with
+[`FastHTML`](https://docs.fastht.ml/api/core.html#fasthtml). This allows
+handlers to access application-level attributes and methods, just like
+using the special `app` parameter name.
+
+Handlers can return tuples containing both content and
+[`HttpHeader`](https://docs.fastht.ml/api/core.html#httpheader) objects.
+[`HttpHeader`](https://docs.fastht.ml/api/core.html#httpheader) allows
+setting custom HTTP headers in the response.
+
+In this example:
+
+- We define a handler that returns both the `chk` attribute from the
+  application and a custom header.
+- The `HttpHeader("mykey", "myval")` sets a custom header in the
+  response.
+- We use the test client to make a request and examine both the response
+  text and headers.
+- The response includes the custom header “mykey” along with standard
+  headers like content-length and content-type.
+
+``` python
+@app.get("/app3")
+def _(foo:FastHTML): return HtmxResponseHeaders(location="http://example.org")
+r = cli.get('/app3')
+print(r.headers)
+```
+
+    Headers({'hx-location': 'http://example.org', 'content-length': '0', 'content-type': 'text/html; charset=utf-8'})
+
+Handler functions can return
+[`HtmxResponseHeaders`](https://docs.fastht.ml/api/core.html#htmxresponseheaders)
+objects to set HTMX-specific response headers. This is useful for
+HTMX-specific behaviors like client-side redirects.
+
+In this example we define a handler that returns an
+[`HtmxResponseHeaders`](https://docs.fastht.ml/api/core.html#htmxresponseheaders)
+object with a `location` parameter, which sets the `HX-Location` header
+in the response. HTMX uses this for client-side redirects.
+
+``` python
+@app.get("/app4")
+def _(foo:FastHTML): return Redirect("http://example.org")
+cli.get('/app4', follow_redirects=False)
+```
+
+    <Response [303 See Other]>
+
+Handler functions can return
+[`Redirect`](https://docs.fastht.ml/api/core.html#redirect) objects to
+perform HTTP redirects. This is useful for redirecting users to
+different pages or external URLs.
+
+In this example:
+
+- We define a handler that returns a
+  [`Redirect`](https://docs.fastht.ml/api/core.html#redirect) object
+  with the URL “http://example.org”.
+- The `cli.get('/app4', follow_redirects=False)` call simulates a GET
+  request to the ‘/app4’ route without following redirects.
+- The response has a 303 See Other status code, indicating a redirect.
+
+The `follow_redirects=False` parameter is used to prevent the test
+client from automatically following the redirect, allowing us to inspect
+the redirect response itself.
+
+``` python
+Redirect.__response__
+```
+
+    <function fasthtml.core.Redirect.__response__(self, req)>
+
+The [`Redirect`](https://docs.fastht.ml/api/core.html#redirect) class in
+FastHTML implements a `__response__` method, which is a special method
+recognized by the framework. When a handler returns a
+[`Redirect`](https://docs.fastht.ml/api/core.html#redirect) object,
+FastHTML internally calls this `__response__` method to replace the
+original response.
+
+The `__response__` method takes a `req` parameter, which represents the
+incoming request. This allows the method to access request information
+if needed when constructing the redirect response.
+
+``` python
+@rt
+def meta(): 
+    return ((Title('hi'),H1('hi')),
+        (Meta(property='image'), Meta(property='site_name')))
+
+print(cli.post('/meta').text)
+```
+
+     <!doctype html>
+     <html>
+       <head>
+         <title>hi</title>
+         <meta property="image">
+         <meta property="site_name">
+         <meta charset="utf-8">
+         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script><script src="https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js"></script><script src="https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js"></script><script src="https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js"></script><script>
+        function sendmsg() {
+            window.parent.postMessage({height: document.documentElement.offsetHeight}, '*');
+        }
+        window.onload = function() {
+            sendmsg();
+            document.body.addEventListener('htmx:afterSettle',    sendmsg);
+            document.body.addEventListener('htmx:wsAfterMessage', sendmsg);
+        };</script>   </head>
+       <body>
+         <h1>hi</h1>
+       </body>
+     </html>
+
+FastHTML automatically identifies elements typically placed in the
+`<head>` (like `Title` and `Meta`) and positions them accordingly, while
+other elements go in the `<body>`.
+
+In this example: - `(Title('hi'), H1('hi'))` defines the title and main
+heading. The title is placed in the head, and the H1 in the body. -
+`(Meta(property='image'), Meta(property='site_name'))` defines two meta
+tags, which are both placed in the head.
+
+## APIRouter
+
+[`APIRouter`](https://docs.fastht.ml/api/core.html#apirouter) is useful
+when you want to split your application routes across multiple `.py`
+files that are part of a single FastHTMl application. It accepts an
+optional `prefix` argument that will be applied to all routes within
+that instance of
+[`APIRouter`](https://docs.fastht.ml/api/core.html#apirouter).
+
+Below we define several hypothetical product related routes in a
+`products.py` and then demonstrate how they can seamlessly be
+incorporated into a FastHTML app instance.
+
+``` python
+# products.py
+ar = APIRouter(prefix="/products")
+
+@ar("/all")
+def all_products(req):
+    return Div(
+        "Welcome to the Products Page! Click the button below to look at the details for product 42",
+        Div(
+            Button(
+                "Details",
+                hx_get=req.url_for("details", pid=42),
+                hx_target="#products_list",
+                hx_swap="outerHTML",
+            ),
+        ),
+        id="products_list",
+    )
+
+
+@ar.get("/{pid}", name="details")
+def details(pid: int):
+    return f"Here are the product details for ID: {pid}"
+```
+
+Since we specified the `prefix=/products` in our hypothetical
+`products.py` file, all routes defined in that file will be found under
+`/products`.
+
+``` python
+print(str(ar.rt_funcs.all_products))
+print(str(ar.rt_funcs.details))
+```
+
+    /products/all
+    /products/{pid}
+
+``` python
+# main.py
+# from products import ar
+
+app, rt = fast_app()
+ar.to_app(app)
+
+@rt
+def index():
+    return Div(
+        "Click me for a look at our products",
+        hx_get=ar.rt_funcs.all_products,
+        hx_swap="outerHTML",
+    )
+```
+
+Note how you can reference our python route functions via
+`APIRouter.rt_funcs` in your `hx_{http_method}` calls like normal.
+
+## Form Data and JSON Handling
+
+``` python
+app = FastHTML()
+rt = app.route
+cli = Client(app)
+```
+
+``` python
+@app.post('/profile/me')
+def profile_update(username: str): return username
+
+r = cli.post('/profile/me', data={'username' : 'Alexis'}).text
+assert r == 'Alexis'
+print(r)
+```
+
+    Alexis
+
+Handler functions can accept form data parameters, without needing to
+manually extract it from the request. In this example, `username` is
+expected to be sent as form data.
+
+The `data` parameter in the `cli.post()` method simulates sending form
+data in the request.
+
+``` python
+r = cli.post('/profile/me', data={})
+assert r.status_code == 400
+print(r.text)
+r
+```
+
+    Missing required field: username
+
+    <Response [400 Bad Request]>
+
+If required form data is missing, FastHTML automatically returns a 400
+Bad Request response with an error message.
+
+``` python
+@app.post('/pet/dog')
+def pet_dog(dogname: str = None): return dogname or 'unknown name'
+r = cli.post('/pet/dog', data={}).text
+r
+```
+
+    'unknown name'
+
+Handlers can have optional form data parameters with default values. In
+this example, `dogname` is an optional parameter with a default value of
+`None`.
+
+Here, if the form data doesn’t include the `dogname` field, the function
+uses the default value. The function returns either the provided
+`dogname` or ‘unknown name’ if `dogname` is `None`.
+
+``` python
+@dataclass
+class Bodie: a:int;b:str
+
+@rt("/bodie/{nm}")
+def post(nm:str, data:Bodie):
+    res = asdict(data)
+    res['nm'] = nm
+    return res
+
+print(cli.post('/bodie/me', data=dict(a=1, b='foo', nm='me')).text)
+```
+
+    {"a":1,"b":"foo","nm":"me"}
+
+You can use dataclasses to define structured form data. In this example,
+`Bodie` is a dataclass with `a` (int) and `b` (str) fields.
+
+FastHTML automatically converts the incoming form data to a `Bodie`
+instance where attribute names match parameter names. Other form data
+elements are matched with parameters with the same names (in this case,
+`nm`).
+
+Handler functions can return dictionaries, which FastHTML automatically
+JSON-encodes.
+
+``` python
+@app.post("/bodied/")
+def bodied(data:dict): return data
+
+d = dict(a=1, b='foo')
+print(cli.post('/bodied/', data=d).text)
+```
+
+    {"a":"1","b":"foo"}
+
+`dict` parameters capture all form data as a dictionary. In this
+example, the `data` parameter is annotated with `dict`, so FastHTML
+automatically converts all incoming form data into a dictionary.
+
+Note that when form data is converted to a dictionary, all values become
+strings, even if they were originally numbers. This is why the ‘a’ key
+in the response has a string value “1” instead of the integer 1.
+
+``` python
+nt = namedtuple('Bodient', ['a','b'])
+
+@app.post("/bodient/")
+def bodient(data:nt): return asdict(data)
+print(cli.post('/bodient/', data=d).text)
+```
+
+    {"a":"1","b":"foo"}
+
+Handler functions can use named tuples to define structured form data.
+In this example, `Bodient` is a named tuple with `a` and `b` fields.
+
+FastHTML automatically converts the incoming form data to a `Bodient`
+instance where field names match parameter names. As with the previous
+example, all form data values are converted to strings in the process.
+
+``` python
+class BodieTD(TypedDict): a:int;b:str='foo'
+
+@app.post("/bodietd/")
+def bodient(data:BodieTD): return data
+print(cli.post('/bodietd/', data=d).text)
+```
+
+    {"a":1,"b":"foo"}
+
+You can use `TypedDict` to define structured form data with type hints.
+In this example, `BodieTD` is a `TypedDict` with `a` (int) and `b` (str)
+fields, where `b` has a default value of ‘foo’.
+
+FastHTML automatically converts the incoming form data to a `BodieTD`
+instance where keys match the defined fields. Unlike with regular
+dictionaries or named tuples, FastHTML respects the type hints in
+`TypedDict`, converting values to the specified types when possible
+(e.g., converting ‘1’ to the integer 1 for the ‘a’ field).
+
+``` python
+class Bodie2:
+    a:int|None; b:str
+    def __init__(self, a, b='foo'): store_attr()
+
+@app.post("/bodie2/")
+def bodie(d:Bodie2): return f"a: {d.a}; b: {d.b}"
+print(cli.post('/bodie2/', data={'a':1}).text)
+```
+
+    a: 1; b: foo
+
+Custom classes can be used to define structured form data. Here,
+`Bodie2` is a custom class with `a` (int|None) and `b` (str) attributes,
+where `b` has a default value of ‘foo’. The `store_attr()` function
+(from fastcore) automatically assigns constructor parameters to instance
+attributes.
+
+FastHTML automatically converts the incoming form data to a `Bodie2`
+instance, matching form fields to constructor parameters. It respects
+type hints and default values.
+
+``` python
+@app.post("/b")
+def index(it: Bodie): return Titled("It worked!", P(f"{it.a}, {it.b}"))
+
+s = json.dumps({"b": "Lorem", "a": 15})
+print(cli.post('/b', headers={"Content-Type": "application/json", 'hx-request':"1"}, data=s).text)
+```
+
+     <title>It worked!</title>
+    <main class="container">   <h1>It worked!</h1>
+       <p>15, Lorem</p>
+    </main>
+
+Handler functions can accept JSON data as input, which is automatically
+parsed into the specified type. In this example, `it` is of type
+`Bodie`, and FastHTML converts the incoming JSON data to a `Bodie`
+instance.
+
+The [`Titled`](https://docs.fastht.ml/api/xtend.html#titled) component
+is used to create a page with a title and main content. It automatically
+generates an `<h1>` with the provided title, wraps the content in a
+`<main>` tag with a “container” class, and adds a `title` to the head.
+
+When making a request with JSON data: - Set the “Content-Type” header to
+“application/json” - Provide the JSON data as a string in the `data`
+parameter of the request
+
+## Cookies, Sessions, File Uploads, and more
+
+``` python
+@rt("/setcookie")
+def get(): return cookie('now', datetime.now())
+
+@rt("/getcookie")
+def get(now:parsed_date): return f'Cookie was set at time {now.time()}'
+
+print(cli.get('/setcookie').text)
+time.sleep(0.01)
+cli.get('/getcookie').text
+```
+
+    'Cookie was set at time 16:19:27.811570'
+
+Handler functions can set and retrieve cookies. In this example:
+
+- The `/setcookie` route sets a cookie named ‘now’ with the current
+  datetime.
+- The `/getcookie` route retrieves the ‘now’ cookie and returns its
+  value.
+
+The [`cookie()`](https://docs.fastht.ml/api/core.html#cookie) function
+is used to create a cookie response. FastHTML automatically converts the
+datetime object to a string when setting the cookie, and parses it back
+to a date object when retrieving it.
+
+``` python
+cookie('now', datetime.now())
+```
+
+    HttpHeader(k='set-cookie', v='now="2025-01-30 16:19:29.997374"; Path=/; SameSite=lax')
+
+The [`cookie()`](https://docs.fastht.ml/api/core.html#cookie) function
+returns an
+[`HttpHeader`](https://docs.fastht.ml/api/core.html#httpheader) object
+with the ‘set-cookie’ key. You can return it in a tuple along with `FT`
+elements, along with anything else FastHTML supports in responses.
+
+``` python
+app = FastHTML(secret_key='soopersecret')
+cli = Client(app)
+rt = app.route
+```
+
+``` python
+@rt("/setsess")
+def get(sess, foo:str=''):
+    now = datetime.now()
+    sess['auth'] = str(now)
+    return f'Set to {now}'
+
+@rt("/getsess")
+def get(sess): return f'Session time: {sess["auth"]}'
+
+print(cli.get('/setsess').text)
+time.sleep(0.01)
+
+cli.get('/getsess').text
+```
+
+    Set to 2025-01-30 16:19:31.078650
+
+    'Session time: 2025-01-30 16:19:31.078650'
+
+Sessions store and retrieve data across requests. To use sessions, you
+should to initialize the FastHTML application with a `secret_key`. This
+is used to cryptographically sign the cookie used by the session.
+
+The `sess` parameter in handler functions provides access to the session
+data. You can set and get session variables using dictionary-style
+access.
+
+``` python
+@rt("/upload")
+async def post(uf:UploadFile): return (await uf.read()).decode()
+
+with open('../../CHANGELOG.md', 'rb') as f:
+    print(cli.post('/upload', files={'uf':f}, data={'msg':'Hello'}).text[:15])
+```
+
+    # Release notes
+
+Handler functions can accept file uploads using Starlette’s `UploadFile`
+type. In this example:
+
+- The `/upload` route accepts a file upload named `uf`.
+- The `UploadFile` object provides an asynchronous `read()` method to
+  access the file contents.
+- We use `await` to read the file content asynchronously and decode it
+  to a string.
+
+We added `async` to the handler function because it uses `await` to read
+the file content asynchronously. In Python, any function that uses
+`await` must be declared as `async`. This allows the function to be run
+asynchronously, potentially improving performance by not blocking other
+operations while waiting for the file to be read.
+
+``` python
+app.static_route('.md', static_path='../..')
+print(cli.get('/README.md').text[:10])
+```
+
+    # FastHTML
+
+The `static_route` method of the FastHTML application allows serving
+static files with specified extensions from a given directory. In this
+example:
+
+- `.md` files are served from the `../..` directory (two levels up from
+  the current directory).
+- Accessing `/README.md` returns the contents of the README.md file from
+  that directory.
+
+``` python
+help(app.static_route_exts)
+```
+
+    Help on method static_route_exts in module fasthtml.core:
+
+    static_route_exts(prefix='/', static_path='.', exts='static') method of fasthtml.core.FastHTML instance
+        Add a static route at URL path `prefix` with files from `static_path` and `exts` defined by `reg_re_param()`
+
+``` python
+app.static_route_exts()
+assert cli.get('/README.txt').status_code == 404
+print(cli.get('/README.txt').text[:50])
+```
+
+    404 Not Found
+
+The `static_route_exts` method of the FastHTML application allows
+serving static files with specified extensions from a given directory.
+By default:
+
+- It serves files from the current directory (‘.’).
+- It uses the ‘static’ regex, which includes common static file
+  extensions like ‘ico’, ‘gif’, ‘jpg’, ‘css’, ‘js’, etc.
+- The URL prefix is set to ‘/’.
+
+The ‘static’ regex is defined by FastHTML using this code:
+
+``` python
+reg_re_param("static", "ico|gif|jpg|jpeg|webm|css|js|woff|png|svg|mp4|webp|ttf|otf|eot|woff2|txt|html|map")
+```
+
+``` python
+@rt("/form-submit/{list_id}")
+def options(list_id: str):
+    headers = {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST',
+        'Access-Control-Allow-Headers': '*',
+    }
+    return Response(status_code=200, headers=headers)
+
+print(cli.options('/form-submit/2').headers)
+```
+
+    Headers({'access-control-allow-origin': '*', 'access-control-allow-methods': 'POST', 'access-control-allow-headers': '*', 'content-length': '0', 'set-cookie': 'session_=eyJhdXRoIjogIjIwMjUtMDEtMzAgMTY6MTk6MzEuMDc4NjUwIn0=.Z5vtZA.1ooY2RCWopWAbLYDy6660g_LlHI; path=/; Max-Age=31536000; httponly; samesite=lax'})
+
+FastHTML handlers can handle OPTIONS requests and set custom headers. In
+this example:
+
+- The `/form-submit/{list_id}` route handles OPTIONS requests.
+- Custom headers are set to allow cross-origin requests (CORS).
+- The function returns a Starlette `Response` object with a 200 status
+  code and the custom headers.
+
+You can return any Starlette Response type from a handler function,
+giving you full control over the response when needed.
+
+``` python
+def _not_found(req, exc): return Div('nope')
+
+app = FastHTML(exception_handlers={404:_not_found})
+cli = Client(app)
+rt = app.route
+
+r = cli.get('/')
+print(r.text)
+```
+
+     <!doctype html>
+     <html>
+       <head>
+         <title>FastHTML page</title>
+         <meta charset="utf-8">
+         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script><script src="https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js"></script><script src="https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js"></script><script src="https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js"></script><script>
+        function sendmsg() {
+            window.parent.postMessage({height: document.documentElement.offsetHeight}, '*');
+        }
+        window.onload = function() {
+            sendmsg();
+            document.body.addEventListener('htmx:afterSettle',    sendmsg);
+            document.body.addEventListener('htmx:wsAfterMessage', sendmsg);
+        };</script>   </head>
+       <body>
+         <div>nope</div>
+       </body>
+     </html>
+
+FastHTML allows you to define custom exception handlers – in this case,
+a custom 404 (Not Found) handler function `_not_found`, which returns a
+`Div` component with the text ‘nope’.</doc><doc title="Live Reloading" desc="Explanation of how to use live reloading for FastHTML development."><!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
+
+<meta charset="utf-8">
+<meta name="generator" content="quarto-1.6.40">
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+
+<title>Live Reloading – fasthtml</title>
+<style>
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+  width: 0.8em;
+  margin: 0 0.8em 0.2em -1em; /* quarto-specific, see https://github.com/quarto-dev/quarto-cli/issues/4556 */ 
+  vertical-align: middle;
+}
+/* CSS for syntax highlighting */
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+  }
+pre.numberSource { margin-left: 3em;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+</style>
+
+
+<script src="../site_libs/quarto-nav/quarto-nav.js"></script>
+<script src="../site_libs/quarto-nav/headroom.min.js"></script>
+<script src="../site_libs/clipboard/clipboard.min.js"></script>
+<script src="../site_libs/quarto-search/autocomplete.umd.js"></script>
+<script src="../site_libs/quarto-search/fuse.min.js"></script>
+<script src="../site_libs/quarto-search/quarto-search.js"></script>
+<meta name="quarto:offset" content="../">
+<link href="../favicon.ico" rel="icon">
+<script src="../site_libs/quarto-html/quarto.js"></script>
+<script src="../site_libs/quarto-html/popper.min.js"></script>
+<script src="../site_libs/quarto-html/tippy.umd.min.js"></script>
+<script src="../site_libs/quarto-html/anchor.min.js"></script>
+<link href="../site_libs/quarto-html/tippy.css" rel="stylesheet">
+<link href="../site_libs/quarto-html/quarto-syntax-highlighting-549806ee2085284f45b00abea8c6df48.css" rel="stylesheet" id="quarto-text-highlighting-styles">
+<script src="../site_libs/bootstrap/bootstrap.min.js"></script>
+<link href="../site_libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
+<link href="../site_libs/bootstrap/bootstrap-b12578cb283c490d3e637e8d6dd1ac43.min.css" rel="stylesheet" append-hash="true" id="quarto-bootstrap" data-mode="light">
+<script id="quarto-search-options" type="application/json">{
+  "location": "navbar",
+  "copy-button": false,
+  "collapse-after": 3,
+  "panel-placement": "end",
+  "type": "overlay",
+  "limit": 50,
+  "keyboard-shortcut": [
+    "f",
+    "/",
+    "s"
+  ],
+  "show-item-context": false,
+  "language": {
+    "search-no-results-text": "No results",
+    "search-matching-documents-text": "matching documents",
+    "search-copy-link-title": "Copy link to search",
+    "search-hide-matches-text": "Hide additional matches",
+    "search-more-match-text": "more match in this document",
+    "search-more-matches-text": "more matches in this document",
+    "search-clear-button-title": "Clear",
+    "search-text-placeholder": "",
+    "search-detached-cancel-button-title": "Cancel",
+    "search-submit-button-title": "Submit",
+    "search-label": "Search"
+  }
+}</script>
+
+
+<link rel="stylesheet" href="../styles.css">
+<meta property="og:title" content="Live Reloading – fasthtml">
+<meta property="og:description" content="The fastest way to create an HTML app">
+<meta property="og:site_name" content="fasthtml">
+<meta name="twitter:title" content="Live Reloading – fasthtml">
+<meta name="twitter:description" content="The fastest way to create an HTML app">
+<meta name="twitter:image" content="https://docs.fastht.ml/og-image.png">
+<meta name="twitter:creator" content="@jeremyphoward">
+<meta name="twitter:site" content="@answerdotai">
+<meta name="twitter:card" content="summary_large_image">
+</head>
+
+<body class="nav-sidebar floating nav-fixed">
+
+<div id="quarto-search-results"></div>
+  <header id="quarto-header" class="headroom fixed-top">
+    <nav class="navbar navbar-expand-lg " data-bs-theme="dark">
+      <div class="navbar-container container-fluid">
+      <div class="navbar-brand-container mx-auto">
+    <a href="../index.html" class="navbar-brand navbar-brand-logo">
+    <img src="../logo.svg" alt="" class="navbar-logo">
+    </a>
+  </div>
+            <div id="quarto-search" class="" title="Search"></div>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" role="menu" aria-expanded="false" aria-label="Toggle navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
+  <span class="navbar-toggler-icon"></span>
+</button>
+          <div class="collapse navbar-collapse" id="navbarCollapse">
+            <ul class="navbar-nav navbar-nav-scroll me-auto">
+  <li class="nav-item">
+    <a class="nav-link" href="https://fastht.ml"> 
+<span class="menu-text">Home</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="https://about.fastht.ml"> 
+<span class="menu-text">Learn</span></a>
+  </li>  
+</ul>
+            <ul class="navbar-nav navbar-nav-scroll ms-auto">
+  <li class="nav-item compact">
+    <a class="nav-link" href="https://github.com/answerdotai/fasthtml"> <i class="bi bi-github" role="img">
+</i> 
+<span class="menu-text"></span></a>
+  </li>  
+  <li class="nav-item compact">
+    <a class="nav-link" href="https://x.com/answerdotai"> <i class="bi bi-twitter" role="img" aria-label="Fast.ai Twitter">
+</i> 
+<span class="menu-text"></span></a>
+  </li>  
+</ul>
+          </div> <!-- /navcollapse -->
+            <div class="quarto-navbar-tools">
+</div>
+      </div> <!-- /container-fluid -->
+    </nav>
+  <nav class="quarto-secondary-nav">
+    <div class="container-fluid d-flex">
+      <button type="button" class="quarto-btn-toggle btn" data-bs-toggle="collapse" role="button" data-bs-target=".quarto-sidebar-collapse-item" aria-controls="quarto-sidebar" aria-expanded="false" aria-label="Toggle sidebar navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
+        <i class="bi bi-layout-text-sidebar-reverse"></i>
+      </button>
+        <nav class="quarto-page-breadcrumbs" aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="../ref/defining_xt_component.html">Reference</a></li><li class="breadcrumb-item"><a href="../ref/live_reload.html">Live Reloading</a></li></ol></nav>
+        <a class="flex-grow-1" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" aria-controls="quarto-sidebar" aria-expanded="false" aria-label="Toggle sidebar navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">      
+        </a>
+    </div>
+  </nav>
+</header>
+<div id="quarto-content" class="quarto-container page-columns page-rows-contents page-layout-article page-navbar">
+  <nav id="quarto-sidebar" class="sidebar collapse collapse-horizontal quarto-sidebar-collapse-item sidebar-navigation floating overflow-auto">
+    <div class="sidebar-menu-container"> 
+    <ul class="list-unstyled mt-1">
+        <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../index.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Get Started</span></a>
+  </div>
+</li>
+        <li class="sidebar-item sidebar-item-section">
+      <div class="sidebar-item-container"> 
+            <a href="../tutorials/index.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Tutorials</span></a>
+          <a class="sidebar-item-toggle text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-1" role="navigation" aria-expanded="true" aria-label="Toggle section">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="quarto-sidebar-section-1" class="collapse list-unstyled sidebar-section depth1 show">  
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../tutorials/by_example.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">FastHTML By Example</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../tutorials/quickstart_for_web_devs.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Web Devs Quickstart</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../tutorials/e2e.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">JS App Walkthrough</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../tutorials/jupyter_and_fasthtml.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Using Jupyter to write FastHTML</span></a>
+  </div>
+</li>
+      </ul>
+  </li>
+        <li class="sidebar-item sidebar-item-section">
+      <div class="sidebar-item-container"> 
+            <a class="sidebar-item-text sidebar-link text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-2" role="navigation" aria-expanded="true">
+ <span class="menu-text">Explanations</span></a>
+          <a class="sidebar-item-toggle text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-2" role="navigation" aria-expanded="true" aria-label="Toggle section">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="quarto-sidebar-section-2" class="collapse list-unstyled sidebar-section depth1 show">  
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/explaining_xt_components.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text"><strong>FT</strong> Components</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/faq.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">FAQ</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/minidataapi.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">MiniDataAPI Spec</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/oauth.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">OAuth</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/routes.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Routes</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../explains/websockets.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">WebSockets</span></a>
+  </div>
+</li>
+      </ul>
+  </li>
+        <li class="sidebar-item sidebar-item-section">
+      <div class="sidebar-item-container"> 
+            <a class="sidebar-item-text sidebar-link text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-3" role="navigation" aria-expanded="true">
+ <span class="menu-text">Reference</span></a>
+          <a class="sidebar-item-toggle text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-3" role="navigation" aria-expanded="true" aria-label="Toggle section">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="quarto-sidebar-section-3" class="collapse list-unstyled sidebar-section depth1 show">  
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../ref/defining_xt_component.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Custom Components</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../ref/handlers.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Handling handlers</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../ref/live_reload.html" class="sidebar-item-text sidebar-link active">
+ <span class="menu-text">Live Reloading</span></a>
+  </div>
+</li>
+      </ul>
+  </li>
+        <li class="sidebar-item sidebar-item-section">
+      <div class="sidebar-item-container"> 
+            <a class="sidebar-item-text sidebar-link text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-4" role="navigation" aria-expanded="true">
+ <span class="menu-text">Source</span></a>
+          <a class="sidebar-item-toggle text-start" data-bs-toggle="collapse" data-bs-target="#quarto-sidebar-section-4" role="navigation" aria-expanded="true" aria-label="Toggle section">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="quarto-sidebar-section-4" class="collapse list-unstyled sidebar-section depth1 show">  
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/core.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Core</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/components.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Components</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/xtend.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Component extensions</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/js.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Javascript examples</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/pico.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Pico.css components</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/svg.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">SVG</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/jupyter.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Jupyter compatibility</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/oauth.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">OAuth</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
+  <a href="../api/cli.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Command Line Tools</span></a>
+  </div>
+</li>
+      </ul>
+  </li>
+    </ul>
+    </div>
+</nav>
+<div id="quarto-sidebar-glass" class="quarto-sidebar-collapse-item" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item"></div>
+    <div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
+        <nav id="TOC" role="doc-toc" class="toc-active">
+    <h2 id="toc-title">On this page</h2>
+   
+  <ul>
+  <li><a href="#live-reloading-with-fast_app" id="toc-live-reloading-with-fast_app" class="nav-link active" data-scroll-target="#live-reloading-with-fast_app">Live reloading with <code>fast_app</code></a></li>
+  </ul>
+<div class="toc-actions"><ul><li><a href="https://github.com/AnswerDotAI/fasthtml/issues/new" class="toc-action"><i class="bi bi-github"></i>Report an issue</a></li></ul></div><div class="quarto-alternate-formats"><h2>Other Formats</h2><ul><li><a href="live_reload.html.md"><i class="bi bi-file-code"></i>CommonMark</a></li></ul></div></nav>
+    </div>
+<main class="content" id="quarto-document-content">
+
+<header id="title-block-header" class="quarto-title-block default"><nav class="quarto-page-breadcrumbs quarto-title-breadcrumbs d-none d-lg-block" aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="../ref/defining_xt_component.html">Reference</a></li><li class="breadcrumb-item"><a href="../ref/live_reload.html">Live Reloading</a></li></ol></nav>
+<div class="quarto-title">
+<h1 class="title">Live Reloading</h1>
+</div>
+
+
+
+<div class="quarto-title-meta">
+
+    
+  
+    
+  </div>
+  
+
+
+</header>
+
+
+<p>When building your app it can be useful to view your changes in a web browser as you make them. FastHTML supports live reloading which means that it watches for any changes to your code and automatically refreshes the webpage in your browser.</p>
+<p>To enable live reloading simply replace <a href="https://docs.fastht.ml/api/core.html#fasthtml"><code>FastHTML</code></a> in your app with <code>FastHTMLWithLiveReload</code>.</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> fasthtml.common <span class="im">import</span> <span class="op">*</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>app <span class="op">=</span> FastHTMLWithLiveReload()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>Then in your terminal run <code>uvicorn</code> with reloading enabled.</p>
+<pre><code>uvicorn main:app --reload</code></pre>
+<p><strong>⚠️ Gotchas</strong> - A reload is only triggered when you save your changes. - <code>FastHTMLWithLiveReload</code> should only be used during development. - If your app spans multiple directories you might need to use the <code>--reload-dir</code> flag to watch all files in each directory. See the uvicorn <a href="https://www.uvicorn.org/settings/#development">docs</a> for more info. - The live reload script is only injected into the page when rendering <a href="https://docs.fastht.ml/explains/explaining_xt_components.html">ft components</a>.</p>
+<section id="live-reloading-with-fast_app" class="level2">
+<h2 class="anchored" data-anchor-id="live-reloading-with-fast_app">Live reloading with <code>fast_app</code></h2>
+<p>In development the <code>fast_app</code> function provides the same functionality. It instantiates the <code>FastHTMLWithLiveReload</code> class if you pass <code>live=True</code>:</p>
+<div class="code-with-filename">
+<div class="code-with-filename-file">
+<pre><strong>main.py</strong></pre>
+</div>
+<div class="sourceCode" id="annotated-cell-3" data-filename="main.py"><pre class="sourceCode python code-annotation-code code-with-copy code-annotated"><code class="sourceCode python"><span id="annotated-cell-3-1"><a href="#annotated-cell-3-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> fasthtml.common <span class="im">import</span> <span class="op">*</span></span>
+<span id="annotated-cell-3-2"><a href="#annotated-cell-3-2" aria-hidden="true" tabindex="-1"></a></span>
+<a class="code-annotation-anchor" data-target-cell="annotated-cell-3" data-target-annotation="1" onclick="event.preventDefault();">1</a><span id="annotated-cell-3-3" class="code-annotation-target"><a href="#annotated-cell-3-3" aria-hidden="true" tabindex="-1"></a>app, rt <span class="op">=</span> fast_app(live<span class="op">=</span><span class="va">True</span>)</span>
+<span id="annotated-cell-3-4"><a href="#annotated-cell-3-4" aria-hidden="true" tabindex="-1"></a></span>
+<a class="code-annotation-anchor" data-target-cell="annotated-cell-3" data-target-annotation="2" onclick="event.preventDefault();">2</a><span id="annotated-cell-3-5" class="code-annotation-target"><a href="#annotated-cell-3-5" aria-hidden="true" tabindex="-1"></a>serve()</span><div class="code-annotation-gutter-bg"></div><div class="code-annotation-gutter"></div></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</div>
+<dl class="code-annotation-container-grid">
+<dt data-target-cell="annotated-cell-3" data-target-annotation="1">1</dt>
+<dd>
+<span data-code-cell="annotated-cell-3" data-code-lines="3" data-code-annotation="1"><code>fast_app()</code> instantiates the <code>FastHTMLWithLiveReload</code> class.</span>
+</dd>
+<dt data-target-cell="annotated-cell-3" data-target-annotation="2">2</dt>
+<dd>
+<span data-code-cell="annotated-cell-3" data-code-lines="5" data-code-annotation="2"><a href="https://docs.fastht.ml/api/core.html#serve"><code>serve()</code></a> is a wrapper around a <code>uvicorn</code> call.</span>
+</dd>
+</dl>
+<p>To run <code>main.py</code> in live reload mode, just do <code>python main.py</code>. We recommend turning off live reload when deploying your app to production.</p>
+
+
+</section>
+
+</main> <!-- /main -->
+<script id="quarto-html-after-body" type="application/javascript">
+window.document.addEventListener("DOMContentLoaded", function (event) {
+  const toggleBodyColorMode = (bsSheetEl) => {
+    const mode = bsSheetEl.getAttribute("data-mode");
+    const bodyEl = window.document.querySelector("body");
+    if (mode === "dark") {
+      bodyEl.classList.add("quarto-dark");
+      bodyEl.classList.remove("quarto-light");
+    } else {
+      bodyEl.classList.add("quarto-light");
+      bodyEl.classList.remove("quarto-dark");
+    }
+  }
+  const toggleBodyColorPrimary = () => {
+    const bsSheetEl = window.document.querySelector("link#quarto-bootstrap");
+    if (bsSheetEl) {
+      toggleBodyColorMode(bsSheetEl);
+    }
+  }
+  toggleBodyColorPrimary();  
+  const icon = "";
+  const anchorJS = new window.AnchorJS();
+  anchorJS.options = {
+    placement: 'right',
+    icon: icon
+  };
+  anchorJS.add('.anchored');
+  const isCodeAnnotation = (el) => {
+    for (const clz of el.classList) {
+      if (clz.startsWith('code-annotation-')) {                     
+        return true;
+      }
+    }
+    return false;
+  }
+  const onCopySuccess = function(e) {
+    // button target
+    const button = e.trigger;
+    // don't keep focus
+    button.blur();
+    // flash "checked"
+    button.classList.add('code-copy-button-checked');
+    var currentTitle = button.getAttribute("title");
+    button.setAttribute("title", "Copied!");
+    let tooltip;
+    if (window.bootstrap) {
+      button.setAttribute("data-bs-toggle", "tooltip");
+      button.setAttribute("data-bs-placement", "left");
+      button.setAttribute("data-bs-title", "Copied!");
+      tooltip = new bootstrap.Tooltip(button, 
+        { trigger: "manual", 
+          customClass: "code-copy-button-tooltip",
+          offset: [0, -8]});
+      tooltip.show();    
+    }
+    setTimeout(function() {
+      if (tooltip) {
+        tooltip.hide();
+        button.removeAttribute("data-bs-title");
+        button.removeAttribute("data-bs-toggle");
+        button.removeAttribute("data-bs-placement");
+      }
+      button.setAttribute("title", currentTitle);
+      button.classList.remove('code-copy-button-checked');
+    }, 1000);
+    // clear code selection
+    e.clearSelection();
+  }
+  const getTextToCopy = function(trigger) {
+      const codeEl = trigger.previousElementSibling.cloneNode(true);
+      for (const childEl of codeEl.children) {
+        if (isCodeAnnotation(childEl)) {
+          childEl.remove();
+        }
+      }
+      return codeEl.innerText;
+  }
+  const clipboard = new window.ClipboardJS('.code-copy-button:not([data-in-quarto-modal])', {
+    text: getTextToCopy
+  });
+  clipboard.on('success', onCopySuccess);
+  if (window.document.getElementById('quarto-embedded-source-code-modal')) {
+    const clipboardModal = new window.ClipboardJS('.code-copy-button[data-in-quarto-modal]', {
+      text: getTextToCopy,
+      container: window.document.getElementById('quarto-embedded-source-code-modal')
+    });
+    clipboardModal.on('success', onCopySuccess);
+  }
+    var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
+    var mailtoRegex = new RegExp(/^mailto:/);
+      var filterRegex = new RegExp("https:\/\/docs\.fastht\.ml\/");
+    var isInternal = (href) => {
+        return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
+    }
+    // Inspect non-navigation links and adorn them if external
+ 	var links = window.document.querySelectorAll('a[href]:not(.nav-link):not(.navbar-brand):not(.toc-action):not(.sidebar-link):not(.sidebar-item-toggle):not(.pagination-link):not(.no-external):not([aria-hidden]):not(.dropdown-item):not(.quarto-navigation-tool):not(.about-link)');
+    for (var i=0; i<links.length; i++) {
+      const link = links[i];
+      if (!isInternal(link.href)) {
+        // undo the damage that might have been done by quarto-nav.js in the case of
+        // links that we want to consider external
+        if (link.dataset.originalHref !== undefined) {
+          link.href = link.dataset.originalHref;
+        }
+      }
+    }
+  function tippyHover(el, contentFn, onTriggerFn, onUntriggerFn) {
+    const config = {
+      allowHTML: true,
+      maxWidth: 500,
+      delay: 100,
+      arrow: false,
+      appendTo: function(el) {
+          return el.parentElement;
+      },
+      interactive: true,
+      interactiveBorder: 10,
+      theme: 'quarto',
+      placement: 'bottom-start',
+    };
+    if (contentFn) {
+      config.content = contentFn;
+    }
+    if (onTriggerFn) {
+      config.onTrigger = onTriggerFn;
+    }
+    if (onUntriggerFn) {
+      config.onUntrigger = onUntriggerFn;
+    }
+    window.tippy(el, config); 
+  }
+  const noterefs = window.document.querySelectorAll('a[role="doc-noteref"]');
+  for (var i=0; i<noterefs.length; i++) {
+    const ref = noterefs[i];
+    tippyHover(ref, function() {
+      // use id or data attribute instead here
+      let href = ref.getAttribute('data-footnote-href') || ref.getAttribute('href');
+      try { href = new URL(href).hash; } catch {}
+      const id = href.replace(/^#\/?/, "");
+      const note = window.document.getElementById(id);
+      if (note) {
+        return note.innerHTML;
+      } else {
+        return "";
+      }
+    });
+  }
+  const xrefs = window.document.querySelectorAll('a.quarto-xref');
+  const processXRef = (id, note) => {
+    // Strip column container classes
+    const stripColumnClz = (el) => {
+      el.classList.remove("page-full", "page-columns");
+      if (el.children) {
+        for (const child of el.children) {
+          stripColumnClz(child);
+        }
+      }
+    }
+    stripColumnClz(note)
+    if (id === null || id.startsWith('sec-')) {
+      // Special case sections, only their first couple elements
+      const container = document.createElement("div");
+      if (note.children && note.children.length > 2) {
+        container.appendChild(note.children[0].cloneNode(true));
+        for (let i = 1; i < note.children.length; i++) {
+          const child = note.children[i];
+          if (child.tagName === "P" && child.innerText === "") {
+            continue;
+          } else {
+            container.appendChild(child.cloneNode(true));
+            break;
+          }
+        }
+        if (window.Quarto?.typesetMath) {
+          window.Quarto.typesetMath(container);
+        }
+        return container.innerHTML
+      } else {
+        if (window.Quarto?.typesetMath) {
+          window.Quarto.typesetMath(note);
+        }
+        return note.innerHTML;
+      }
+    } else {
+      // Remove any anchor links if they are present
+      const anchorLink = note.querySelector('a.anchorjs-link');
+      if (anchorLink) {
+        anchorLink.remove();
+      }
+      if (window.Quarto?.typesetMath) {
+        window.Quarto.typesetMath(note);
+      }
+      if (note.classList.contains("callout")) {
+        return note.outerHTML;
+      } else {
+        return note.innerHTML;
+      }
+    }
+  }
+  for (var i=0; i<xrefs.length; i++) {
+    const xref = xrefs[i];
+    tippyHover(xref, undefined, function(instance) {
+      instance.disable();
+      let url = xref.getAttribute('href');
+      let hash = undefined; 
+      if (url.startsWith('#')) {
+        hash = url;
+      } else {
+        try { hash = new URL(url).hash; } catch {}
+      }
+      if (hash) {
+        const id = hash.replace(/^#\/?/, "");
+        const note = window.document.getElementById(id);
+        if (note !== null) {
+          try {
+            const html = processXRef(id, note.cloneNode(true));
+            instance.setContent(html);
+          } finally {
+            instance.enable();
+            instance.show();
+          }
+        } else {
+          // See if we can fetch this
+          fetch(url.split('#')[0])
+          .then(res => res.text())
+          .then(html => {
+            const parser = new DOMParser();
+            const htmlDoc = parser.parseFromString(html, "text/html");
+            const note = htmlDoc.getElementById(id);
+            if (note !== null) {
+              const html = processXRef(id, note);
+              instance.setContent(html);
+            } 
+          }).finally(() => {
+            instance.enable();
+            instance.show();
+          });
+        }
+      } else {
+        // See if we can fetch a full url (with no hash to target)
+        // This is a special case and we should probably do some content thinning / targeting
+        fetch(url)
+        .then(res => res.text())
+        .then(html => {
+          const parser = new DOMParser();
+          const htmlDoc = parser.parseFromString(html, "text/html");
+          const note = htmlDoc.querySelector('main.content');
+          if (note !== null) {
+            // This should only happen for chapter cross references
+            // (since there is no id in the URL)
+            // remove the first header
+            if (note.children.length > 0 && note.children[0].tagName === "HEADER") {
+              note.children[0].remove();
+            }
+            const html = processXRef(null, note);
+            instance.setContent(html);
+          } 
+        }).finally(() => {
+          instance.enable();
+          instance.show();
+        });
+      }
+    }, function(instance) {
+    });
+  }
+      let selectedAnnoteEl;
+      const selectorForAnnotation = ( cell, annotation) => {
+        let cellAttr = 'data-code-cell="' + cell + '"';
+        let lineAttr = 'data-code-annotation="' +  annotation + '"';
+        const selector = 'span[' + cellAttr + '][' + lineAttr + ']';
+        return selector;
+      }
+      const selectCodeLines = (annoteEl) => {
+        const doc = window.document;
+        const targetCell = annoteEl.getAttribute("data-target-cell");
+        const targetAnnotation = annoteEl.getAttribute("data-target-annotation");
+        const annoteSpan = window.document.querySelector(selectorForAnnotation(targetCell, targetAnnotation));
+        const lines = annoteSpan.getAttribute("data-code-lines").split(",");
+        const lineIds = lines.map((line) => {
+          return targetCell + "-" + line;
+        })
+        let top = null;
+        let height = null;
+        let parent = null;
+        if (lineIds.length > 0) {
+            //compute the position of the single el (top and bottom and make a div)
+            const el = window.document.getElementById(lineIds[0]);
+            top = el.offsetTop;
+            height = el.offsetHeight;
+            parent = el.parentElement.parentElement;
+          if (lineIds.length > 1) {
+            const lastEl = window.document.getElementById(lineIds[lineIds.length - 1]);
+            const bottom = lastEl.offsetTop + lastEl.offsetHeight;
+            height = bottom - top;
+          }
+          if (top !== null && height !== null && parent !== null) {
+            // cook up a div (if necessary) and position it 
+            let div = window.document.getElementById("code-annotation-line-highlight");
+            if (div === null) {
+              div = window.document.createElement("div");
+              div.setAttribute("id", "code-annotation-line-highlight");
+              div.style.position = 'absolute';
+              parent.appendChild(div);
+            }
+            div.style.top = top - 2 + "px";
+            div.style.height = height + 4 + "px";
+            div.style.left = 0;
+            let gutterDiv = window.document.getElementById("code-annotation-line-highlight-gutter");
+            if (gutterDiv === null) {
+              gutterDiv = window.document.createElement("div");
+              gutterDiv.setAttribute("id", "code-annotation-line-highlight-gutter");
+              gutterDiv.style.position = 'absolute';
+              const codeCell = window.document.getElementById(targetCell);
+              const gutter = codeCell.querySelector('.code-annotation-gutter');
+              gutter.appendChild(gutterDiv);
+            }
+            gutterDiv.style.top = top - 2 + "px";
+            gutterDiv.style.height = height + 4 + "px";
+          }
+          selectedAnnoteEl = annoteEl;
+        }
+      };
+      const unselectCodeLines = () => {
+        const elementsIds = ["code-annotation-line-highlight", "code-annotation-line-highlight-gutter"];
+        elementsIds.forEach((elId) => {
+          const div = window.document.getElementById(elId);
+          if (div) {
+            div.remove();
+          }
+        });
+        selectedAnnoteEl = undefined;
+      };
+        // Handle positioning of the toggle
+    window.addEventListener(
+      "resize",
+      throttle(() => {
+        elRect = undefined;
+        if (selectedAnnoteEl) {
+          selectCodeLines(selectedAnnoteEl);
+        }
+      }, 10)
+    );
+    function throttle(fn, ms) {
+    let throttle = false;
+    let timer;
+      return (...args) => {
+        if(!throttle) { // first call gets through
+            fn.apply(this, args);
+            throttle = true;
+        } else { // all the others get throttled
+            if(timer) clearTimeout(timer); // cancel #2
+            timer = setTimeout(() => {
+              fn.apply(this, args);
+              timer = throttle = false;
+            }, ms);
+        }
+      };
+    }
+      // Attach click handler to the DT
+      const annoteDls = window.document.querySelectorAll('dt[data-target-cell]');
+      for (const annoteDlNode of annoteDls) {
+        annoteDlNode.addEventListener('click', (event) => {
+          const clickedEl = event.target;
+          if (clickedEl !== selectedAnnoteEl) {
+            unselectCodeLines();
+            const activeEl = window.document.querySelector('dt[data-target-cell].code-annotation-active');
+            if (activeEl) {
+              activeEl.classList.remove('code-annotation-active');
+            }
+            selectCodeLines(clickedEl);
+            clickedEl.classList.add('code-annotation-active');
+          } else {
+            // Unselect the line
+            unselectCodeLines();
+            clickedEl.classList.remove('code-annotation-active');
+          }
+        });
+      }
+  const findCites = (el) => {
+    const parentEl = el.parentElement;
+    if (parentEl) {
+      const cites = parentEl.dataset.cites;
+      if (cites) {
+        return {
+          el,
+          cites: cites.split(' ')
+        };
+      } else {
+        return findCites(el.parentElement)
+      }
+    } else {
+      return undefined;
+    }
+  };
+  var bibliorefs = window.document.querySelectorAll('a[role="doc-biblioref"]');
+  for (var i=0; i<bibliorefs.length; i++) {
+    const ref = bibliorefs[i];
+    const citeInfo = findCites(ref);
+    if (citeInfo) {
+      tippyHover(citeInfo.el, function() {
+        var popup = window.document.createElement('div');
+        citeInfo.cites.forEach(function(cite) {
+          var citeDiv = window.document.createElement('div');
+          citeDiv.classList.add('hanging-indent');
+          citeDiv.classList.add('csl-entry');
+          var biblioDiv = window.document.getElementById('ref-' + cite);
+          if (biblioDiv) {
+            citeDiv.innerHTML = biblioDiv.innerHTML;
+          }
+          popup.appendChild(citeDiv);
+        });
+        return popup.innerHTML;
+      });
+    }
+  }
+});
+</script>
+</div> <!-- /content -->
+
+
+
+
+<footer class="footer"><div class="nav-footer"><div class="nav-footer-center"><div class="toc-actions d-sm-block d-md-none"><ul><li><a href="https://github.com/AnswerDotAI/fasthtml/issues/new" class="toc-action"><i class="bi bi-github"></i>Report an issue</a></li></ul></div></div></div></footer></body></html></doc></optional></project>

--- a/nbs/llms-ctx.txt
+++ b/nbs/llms-ctx.txt
@@ -60,9 +60,8 @@ write a properly formed web page. You’ll soon see the power of this
 approach.
 
 Line 9  
-The
-[`serve()`](https://AnswerDotAI.github.io/fasthtml/api/core.html#serve)
-utility configures and runs FastHTML using a library called `uvicorn`.
+The [`serve()`](https://docs.fastht.ml/api/core.html#serve) utility
+configures and runs FastHTML using a library called `uvicorn`.
 
 Run the code:
 
@@ -103,10 +102,9 @@ the image below:
 
 ## A Minimal Charting Application
 
-The
-[`Script`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#script)
-function allows you to include JavaScript. You can use Python to
-generate parts of your JS or JSON like this:
+The [`Script`](https://docs.fastht.ml/api/xtend.html#script) function
+allows you to include JavaScript. You can use Python to generate parts
+of your JS or JSON like this:
 
 ``` python
 import json
@@ -348,14 +346,13 @@ This will generate an HTML `<link>` tag for sourcing the css for Sakura.
 
 Line 8  
 If you want an inline styles, the
-[`Style()`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#style)
-function will put the result into the HTML.
+[`Style()`](https://docs.fastht.ml/api/xtend.html#style) function will
+put the result into the HTML.
 
 ## Other Static Media File Locations
 
-As you saw,
-[`Script`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#script)
-and `Link` are specific to the most common static media use cases in web
+As you saw, [`Script`](https://docs.fastht.ml/api/xtend.html#script) and
+`Link` are specific to the most common static media use cases in web
 apps: including JavaScript, CSS, and images. But it also works with
 videos and other static media files. The default behavior is to look for
 these files in the root directory - typically we don’t do anything
@@ -614,7 +611,7 @@ profile
     Profile(email='john@example.com', phone='123456789', age=5)
 
 Then add that data to the `profile_form` using FastHTML’s
-[`fill_form`](https://AnswerDotAI.github.io/fasthtml/api/components.html#fill_form)
+[`fill_form`](https://docs.fastht.ml/api/components.html#fill_form)
 class:
 
 ``` python
@@ -816,8 +813,8 @@ serve()
 ## Cookies
 
 We can set cookies using the
-[`cookie()`](https://AnswerDotAI.github.io/fasthtml/api/core.html#cookie)
-function. In our example, we’ll create a `timestamp` cookie.
+[`cookie()`](https://docs.fastht.ml/api/core.html#cookie) function. In
+our example, we’ll create a `timestamp` cookie.
 
 ``` python
 from datetime import datetime
@@ -947,10 +944,9 @@ def user_auth_before(req, sess):
 ```
 
 Now we pass our `user_auth_before` function as the first argument into a
-[`Beforeware`](https://AnswerDotAI.github.io/fasthtml/api/core.html#beforeware)
-class. We also pass a list of regular expressions to the `skip`
-argument, designed to allow users to still get to the home and login
-pages.
+[`Beforeware`](https://docs.fastht.ml/api/core.html#beforeware) class.
+We also pass a list of regular expressions to the `skip` argument,
+designed to allow users to still get to the home and login pages.
 
 ``` python
 beforeware = Beforeware(
@@ -1037,7 +1033,7 @@ that plugs nicely into HTMX in the browser
 
 Line 26  
 The endpoint view needs to be an async function that returns a
-[`EventStream`](https://AnswerDotAI.github.io/fasthtml/api/core.html#eventstream)
+[`EventStream`](https://docs.fastht.ml/api/core.html#eventstream)
 
 ## Websockets
 
@@ -1204,8 +1200,8 @@ serve()
 
 Line 13  
 Every form rendered with the
-[`Form`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#form) FT
-component defaults to `enctype="multipart/form-data"`
+[`Form`](https://docs.fastht.ml/api/xtend.html#form) FT component
+defaults to `enctype="multipart/form-data"`
 
 Line 14  
 Don’t forget to set the `Input` FT Component’s type to `file`
@@ -1275,8 +1271,8 @@ serve()
 
 Line 13  
 Every form rendered with the
-[`Form`](https://AnswerDotAI.github.io/fasthtml/api/xtend.html#form) FT
-component defaults to `enctype="multipart/form-data"`
+[`Form`](https://docs.fastht.ml/api/xtend.html#form) FT component
+defaults to `enctype="multipart/form-data"`
 
 Line 14  
 Don’t forget to set the `Input` FT Component’s type to `file` and assign
@@ -2567,7 +2563,7 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
     - `def __response__(self, req)`
 
 - `def qp(p, **kw)`
-    Add query parameters to path p
+    Add parameters kw to path p
 
 - `def def_hdrs(htmx, surreal)`
     Default headers for a FastHTML app
@@ -2678,6 +2674,13 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
     Start and stop a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`
 
     - `def __init__(self, app, log_level, host, port, start, **kwargs)`
+    - `def start(self)`
+    - `def stop(self)`
+
+- `class JupyUviAsync`
+    Start and stop an async Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`
+
+    - `def __init__(self, app, log_level, host, port, **kwargs)`
     - `def start(self)`
     - `def stop(self)`
 

--- a/nbs/llms.txt
+++ b/nbs/llms.txt
@@ -30,4 +30,15 @@ Things to remember when writing FastHTML apps:
 ## Optional
 
 - [Starlette full documentation](https://gist.githubusercontent.com/jph00/809e4a4808d4510be0e3dc9565e9cbd3/raw/9b717589ca44cedc8aaf00b2b8cacef922964c0f/starlette-sml.md): A subset of the Starlette documentation useful for FastHTML development.
-
+- [JS App Walkthrough](https://docs.fastht.ml/tutorials/e2e.html.md): An end-to-end walkthrough of a complete FastHTML app, including deployment to railway.
+- [FastHTML by Example](https://docs.fastht.ml/tutorials/by_example.html.md): A collection of 4 FastHTML apps showcasing idiomatic use of FastHTML and HTMX patterns.
+- [Using Jupyter to write FastHTML](https://docs.fastht.ml/tutorials/jupyter_and_fasthtml.html.md): A guide to developing FastHTML apps inside Jupyter notebooks.
+- [FT Components](https://docs.fastht.ml/explains/explaining_xt_components.html.md): Explanation of the `FT` components, which are a way to write HTML in a Pythonic way.
+- [FAQ](https://docs.fastht.ml/explains/faq.html.md): Answers to common questions about FastHTML.
+- [MiniDataAPI Spec](https://docs.fastht.ml/explains/minidataapi.html.md): Explanation of the MiniDataAPI specification, which allows us to use the same API for many different database engines.
+- [OAuth](https://docs.fastht.ml/explains/oauth.html.md): Tutorial and explanation of how to use OAuth in FastHTML apps.
+- [Routes](https://docs.fastht.ml/explains/routes.html.md): Explanation of how routes work in FastHTML.
+- [WebSockets](https://docs.fastht.ml/explains/websockets.html): Explanation of websockets and how they work in FastHTML.
+- [Custom Components](https://docs.fastht.ml/ref/defining_xt_component.html.md): Explanation of how to create custom components in FastHTML.
+- [Handling Handlers](https://docs.fastht.ml/ref/handlers.html.md): Explanation of how to request and response handlers work in FastHTML as routes.
+- [Live Reloading](https://docs.fastht.ml/ref/live_reload.html): Explanation of how to use live reloading for FastHTML development.


### PR DESCRIPTION
This PR  expands the optional section in fasthtml's llms.txt to include all tutorials and explanations.

Changes:
- Added all the tutorials and explanations to the optional section in llms.txt
- Updated corresponding ctx and ctx-full versions to match
- Fixed description of qp() function in the `core.pyi` using the `tools/update.sh` script.

These changes help ensure developers utilizing our llms.txt are able to get access to all our documentation.