### PR TITLE
Make the H1 tag optional, so you can add your own

### DIFF
--- a/fasthtml/xtend.py
+++ b/fasthtml/xtend.py
@@ -180,9 +180,11 @@ def jsd(org, repo, root, path, prov='gh', typ='script', ver=None, esm=False, **k
 
 # %% ../nbs/api/02_xtend.ipynb
 @delegates(ft_hx, keep=True)
-def Titled(title:str="FastHTML app", *args, cls="container", **kwargs)->FT:
+def Titled(
+    title:str="FastHTML app", *args, cls="container", titled_h1=True, **kwargs)->FT:
     "An HTML partial containing a `Title`, and `H1`, and any provided children"
-    return Title(title), Main(H1(title), *args, cls=cls, **kwargs)
+    main_title = H1(title) if titled_h1 else None
+    return Title(title), Main(main_title, *args, cls=cls, **kwargs)
 
 # %% ../nbs/api/02_xtend.ipynb
 def Socials(title, site_name, description, image, url=None, w=1200, h=630, twitter_site=None, creator=None, card='summary'):

--- a/nbs/api/02_xtend.ipynb
+++ b/nbs/api/02_xtend.ipynb
@@ -503,9 +503,19 @@
    "source": [
     "#| export\n",
     "@delegates(ft_hx, keep=True)\n",
-    "def Titled(title:str=\"FastHTML app\", *args, cls=\"container\", **kwargs)->FT:\n",
+    "def Titled(\n",
+    "    title:str=\"FastHTML app\", *args, cls=\"container\", titled_h1=True, **kwargs)->FT:\n",
     "    \"An HTML partial containing a `Title`, and `H1`, and any provided children\"\n",
-    "    return Title(title), Main(H1(title), *args, cls=cls, **kwargs)"
+    "    main_title = H1(title) if titled_h1 else None\n",
+    "    return Title(title), Main(main_title, *args, cls=cls, **kwargs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8cc3e3f",
+   "metadata": {},
+   "source": [
+    "The `titled_h1` parameter allows you to disable the default `H1` generated tag, and add your own heading instead. This could be useful, for example, if you wanted to tweak the browser title text for SEO purposes, or to add the `H1` in a different location in the markup (i.e. inside a navbar)."
    ]
   },
   {


### PR DESCRIPTION
---
name: Pull Request
about: Make the `Titled()` a little more flexible by making the default generated H1 tag optional
title: '[PR] Make the H1 tag optional, so you can add your own'
labels: ''
assignees: ''
---

**Proposed Changes**
`Titled()` is a useful component but I don't sometimes use it as I need to specify a different `H1` text for the page heading. Or perhaps I need to add it inside a navbar rather than it be the first direct child of `Main()`.

e.g.
```python
from fasthtml.common import *

app,rt = fast_app(live=True)

@rt('/')
def get(): return Titled(
	"Page Title",
	H1("My Page Title"),
	Div(P("Hello, world!!")),
	titled_h1=False
)

serve()
```

Or:
```python
from fasthtml.common import *

app,rt = fast_app(live=True)

@rt('/')
def get(): return Titled(
	"Page Title",
	Div(
		H1("My Page Title"),
		P("Hello, world!!")
	),
	titled_h1=False
)

serve()
```

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.