### PR TITLE
handle for when there is a type hint on session

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -174,6 +174,7 @@ async def _find_p(req, arg:str, p:Parameter):
         if issubclass(anno, Request): return req
         if issubclass(anno, HtmxHeaders): return _get_htmx(req.headers)
         if issubclass(anno, Starlette): return req.scope['app']
+        if _is_body(anno) and 'session'.startswith(arg.lower()): return req.scope.get('session', {})
         if _is_body(anno): return await _from_body(req, p)
     # If there's no annotation, check for special names
     if anno is empty:

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -627,6 +627,7 @@
     "        if issubclass(anno, Request): return req\n",
     "        if issubclass(anno, HtmxHeaders): return _get_htmx(req.headers)\n",
     "        if issubclass(anno, Starlette): return req.scope['app']\n",
+    "        if _is_body(anno) and 'session'.startswith(arg.lower()): return req.scope.get('session', {})\n",
     "        if _is_body(anno): return await _from_body(req, p)\n",
     "    # If there's no annotation, check for special names\n",
     "    if anno is empty:\n",
@@ -1652,7 +1653,7 @@
    "source": [
     "@app.get('/foo/{a}')\n",
     "def foo(a:str, b:list[int]): ...\n",
-    "    \n",
+    "\n",
     "foo.to(a='bar', b=[1,2])"
    ]
   },

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -19,6 +19,10 @@ def post(session):
 def get(session):
     return Titled("Hello, world!", P(str(session)))
 
+@rt("/see-toast-with-typehint")
+def get(session: dict):
+    return Titled("Hello, world!", P(str(session)))
+
 @rt("/see-toast-ft-response")
 def get(session):
     add_toast(session, "Toast FtResponse", "info")
@@ -40,6 +44,13 @@ def test_post_toaster():
 def test_ft_response():
     res = cli.get('/see-toast-ft-response')
     assert 'Toast FtResponse' in res.text
+
+def test_get_toaster_with_typehint():
+    res = cli.get('/see-toast-with-typehint', follow_redirects=False)
+    assert 'Toast get' in res.text
+
+    res = cli.get('/see-toast-with-typehint', follow_redirects=True)
+    assert 'Toast get' in res.text
 
 test_get_toaster()
 test_post_toaster()


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
https://github.com/AnswerDotAI/fasthtml/issues/635

**Proposed Changes**
I saw the issue and that when typed hinted, session was being handled as body. I was not sure whether to create or new function or just handle before as body is also a `dict`. Looks like this may also be true for other args like `auth` which I can add here (but wasn't sure it was ever a function arg).

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
