### PR TITLE
Toast container duplication fix

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -1,5 +1,4 @@
 from fastcore.xml import FT
-from functools import partial
 from fasthtml.core import *
 from fasthtml.components import *
 from fasthtml.xtend import *
@@ -54,11 +53,11 @@ def render_toasts(sess):
 
 def toast_after(resp, req, sess):
     if sk in sess and (not resp or isinstance(resp, (tuple, FT, FtResponse))):
-        sess['toast_duration'] = req.app.state.toast_duration  # Get duration from app state
+        sess['toast_duration'] = req.app.state.toast_duration
         req.injects.append(render_toasts(sess))
 
 def setup_toasts(app, duration=5000):
     app.ftrs.append(ToastCtn())
-    app.state.toast_duration = duration  # Store duration in app state
+    app.state.toast_duration = duration
     app.hdrs += (Style(toast_css),)
     app.after.append(toast_after)


### PR DESCRIPTION
---
name: Pull Request
about: Fix for duplicate toast containers
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
Mentioned in the FastHTML discord by user `78wesley` and validated locally.

**Proposed Changes**
Toast containers were being spawned in overlapping contexts and thus rendering incorrectly when using multiple `add_toast` methods. 

I've been through the gist provided by 78wesley in the discord, and it did indeed fix the issue. I've done a cleanup/ revamp of the `toaster.py` file to fix the issues, and also removed the javascript in favour of htmx.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Demo**


https://github.com/user-attachments/assets/a302e236-8dc0-4508-8ace-a65dce078f9a



