### PR TITLE
Fix broken link on ..explaines/FtComponents Page

### DIFF
--- a/nbs/explains/explaining_xt_components.ipynb
+++ b/nbs/explains/explaining_xt_components.ipynb
@@ -280,7 +280,7 @@
     "\n",
     "It is possible and sometimes useful to create your own ft components that generate non-standard tags that are not in the FastHTML library.  FastHTML supports created and defining those new tags flexibly.\n",
     "\n",
-    "For more information, see the [Defining new ft components](/ref/defining_xt_component) reference page."
+    "For more information, see the [Defining new ft components](/ref/defining_xt_component.html) reference page."
    ]
   },
   {


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
[Issue 676](https://github.com/AnswerDotAI/fasthtml/issues/676)

**Proposed Changes**
Fix Markup for link - add missing html

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
This is a simple fix just fixed a link in the docs. 
