### PR TITLE
Toast bug fixes

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -1,29 +1,29 @@
 from fastcore.xml import FT
-from fasthtml.core import *
+from fasthtml.core import FtResponse
 from fasthtml.components import *
 from fasthtml.xtend import *
 
-tcid = "fh-toast-container"
+tcid='fh-toast-container'
 sk = "toasts"
 toast_css = """
 #fh-toast-container {
-    position: fixed; inset: 20px 0; z-index: 1000;
-    display: flex; flex-direction: column; align-items: stretch;
-    gap: 10px; pointer-events: none; max-width: 80%; margin: 0 auto;
+    position: fixed; inset: 20px 0; z-index: 1000; max-width: 80vw;
+    display: flex; flex-direction: column; align-items: center;
+    gap: 10px; pointer-events: none; margin: 0 auto;
 }
 .fh-toast {
     background-color: #333; color: white;
     padding: 12px 28px 12px 20px; border-radius: 4px;
-    text-align: center; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    opacity: 0.9; position: relative;
-    transition: opacity 150ms ease-in-out; &.htmx-swapping { opacity: 0; }
+    text-align: center; opacity: 0.9; position: relative;
+    & > * { pointer-events: auto; };
+    transition: opacity 150ms ease-in-out; min-width: 400px;
     @starting-style { opacity: 0.2; };
 }
 .fh-toast-dismiss {
     position: absolute; top: .2em; right: .4em;
     line-height: 1rem; padding: 0 .2em .2em .2em;
     border-radius: 15%; filter:drop-shadow(0 0 1px black);
-    background: inherit; color:inherit; pointer-events: auto;
+    background: inherit; color:inherit;
     transition: filter 150ms ease-in-out;
     filter:brightness(0.8); &:hover { filter:brightness(0.9); }
 }
@@ -33,31 +33,26 @@ toast_css = """
 .fh-toast-error { background-color: #F44336; }
 """
 
-def ToastCtn(toasts=[]):
-    return Div(*toasts, id=tcid, hx_swap_oob="afterbegin")
-
 def Toast(message: str, typ: str = "info", dismiss: bool = False, duration:int=5000):
-    x_btn = Button('x', cls="fh-toast-dismiss", hx_swap="delete swap:150ms",
-                    hx_get=True, hx_target=f"closest .fh-toast") if dismiss else None
-    return Div(message, x_btn, cls=f"fh-toast fh-toast-{typ}", hx_trigger=f"load delay:{duration}ms", hx_swap=f"delete swap:150ms", hx_get=True)
+    x_btn = Button('x', cls="fh-toast-dismiss", onclick="htmx.remove(this?.parentElement);") if dismiss else None
+    return Div(Div(Span(message), x_btn, cls=f"fh-toast fh-toast-{typ}", hx_on_transitionend="setTimeout(() => this?.remove(), %d);" % duration), hx_swap_oob=f"afterbegin:#{tcid}")
 
 def add_toast(sess, message: str, typ: str = "info", dismiss: bool = False):
     assert typ in ("info", "success", "warning", "error"), '`typ` not in ("info", "success", "warning", "error")'
     sess.setdefault(sk, []).append((message, typ, dismiss))
 
-
 def render_toasts(sess):
     toasts = [Toast(msg, typ, dismiss, sess['toast_duration']) 
               for msg, typ, dismiss in sess.pop(sk, [])]
-    return ToastCtn(toasts)
+    return Div(*toasts)
 
 def toast_after(resp, req, sess):
-    if sk in sess and (not resp or isinstance(resp, (tuple, FT, FtResponse))):
+    if sk in sess and (not resp or isinstance(resp, (tuple,FT,FtResponse))):
         sess['toast_duration'] = req.app.state.toast_duration
         req.injects.append(render_toasts(sess))
 
+js = Script("htmx.onLoad(() => {if (!document.querySelector('#%s')){const elm = document.createElement('div'); elm.id='%s'; document.body.prepend(elm);}})" % (tcid, tcid))
 def setup_toasts(app, duration=5000):
-    app.ftrs.append(ToastCtn())
     app.state.toast_duration = duration
-    app.hdrs += (Style(toast_css),)
+    app.hdrs += [Style(toast_css), js]
     app.after.append(toast_after)


### PR DESCRIPTION
---
name: Toast container bug fixes
about: Modifications to ensure `toasts` work well with htmx.
title: '[PR] '
labels: ''
assignees: "

---

**Related Issues**
Fixes: #662
Fixes: #683

**Proposed Changes**
Instead of using HTMX ajax requests to issue the removal logic, I've changed to an inline client-side removal handler. It uses the `hx-on` attribute to listen for a transitionend event, which is fired when the toast loads into view. This will trigger the `setTimeout()` call to begin and, if the toast hasn't been manually dismissed will remove it.

After exploring options for a while, the only working option I found required a small amount of javascript to make the OOB swaps work for htmx requested routes too. These two changes should make the toasts functionality much more versatile and less likely to break existing htmx-heavy FastHTML apps.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Demo**

https://github.com/user-attachments/assets/348e2d94-1b0f-4b24-ad94-8f799e1af17b

