### PR TITLE
update `_formitem` so that it doesn't raise `KeyError`

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -131,7 +131,7 @@ def _is_body(anno): return issubclass(anno, (dict,ns)) or _annotations(anno)
 # %% ../nbs/api/00_core.ipynb
 def _formitem(form, k):
     "Return single item `k` from `form` if len 1, otherwise return list"
-    if isinstance(form, dict): return form[k]
+    if isinstance(form, dict): return form.get(k)
     o = form.getlist(k)
     return o[0] if len(o) == 1 else o if o else None
 

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -131,7 +131,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2025, 3, 16, 14, 0)"
+       "datetime.datetime(2025, 3, 28, 14, 0)"
       ]
      },
      "execution_count": null,
@@ -487,7 +487,7 @@
     "#| export\n",
     "def _formitem(form, k):\n",
     "    \"Return single item `k` from `form` if len 1, otherwise return list\"\n",
-    "    if isinstance(form, dict): return form[k]\n",
+    "    if isinstance(form, dict): return form.get(k)\n",
     "    o = form.getlist(k)\n",
     "    return o[0] if len(o) == 1 else o if o else None"
    ]
@@ -710,6 +710,82 @@
     "\n",
     "client = TestClient(Starlette(routes=[Route('/', f, methods=['POST'])]))\n",
     "response = client.post('/?a=1', data=d)\n",
+    "print(response.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34066c89",
+   "metadata": {},
+   "source": [
+    "**Missing Request Params**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06259883",
+   "metadata": {},
+   "source": [
+    "If a request param has a default value (e.g. `a:str=''`), the request is valid even if the user doesn't include the param in their request."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c369a89c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[<starlette.requests.Request object>, <starlette.applications.Starlette object>, '']\n"
+     ]
+    }
+   ],
+   "source": [
+    "def g(req, this:Starlette, a:str=''): ...\n",
+    "\n",
+    "async def f(req):\n",
+    "    a = await _wrap_req(req, _params(g))\n",
+    "    return Response(str(a))\n",
+    "\n",
+    "client = TestClient(Starlette(routes=[Route('/', f, methods=['POST'])]))\n",
+    "response = client.post('/', json={}) # no param in request\n",
+    "print(response.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35b68f4f",
+   "metadata": {},
+   "source": [
+    "If we remove the default value and re-run the request, we should get the following error `Missing required field: a`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b33b43a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Missing required field: a\n"
+     ]
+    }
+   ],
+   "source": [
+    "def g(req, this:Starlette, a:str): ...\n",
+    "\n",
+    "async def f(req):\n",
+    "    a = await _wrap_req(req, _params(g))\n",
+    "    return Response(str(a))\n",
+    "\n",
+    "client = TestClient(Starlette(routes=[Route('/', f, methods=['POST'])]))\n",
+    "response = client.post('/', json={}) # no param in request\n",
     "print(response.text)"
    ]
   },
@@ -3342,9 +3418,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "python",
    "language": "python",
-   "name": "python3"
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
If the user doesn't include all request params in their request a `KeyError` will be raised when running `_find_p`.

---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
#693 

**Proposed Changes**
This pr updates `_formitem` so that is does a safe dict lookup and no longer throws a `KeyError`.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
N/A
