### PR TITLE
[PR] Allow any Mapping children to specify attributes. fix #737

### DIFF
--- a/fasthtml/components.py
+++ b/fasthtml/components.py
@@ -19,7 +19,8 @@ __all__ = ['named', 'html_attrs', 'hx_attrs', 'hx_evts', 'js_evts', 'hx_attrs_an
 # %% ../nbs/api/01_components.ipynb
 from dataclasses import dataclass, asdict, is_dataclass, make_dataclass, replace, astuple, MISSING
 from bs4 import BeautifulSoup, Comment
-from typing import Literal, Optional
+from collections import UserDict
+from typing import Literal, Mapping, Optional
 
 from fastcore.utils import *
 from fastcore.xml import *
@@ -84,7 +85,7 @@ fh_cfg['auto_name']=True
 
 # %% ../nbs/api/01_components.ipynb
 def ft_html(tag: str, *c, id=None, cls=None, title=None, style=None, attrmap=None, valmap=None, ft_cls=None, **kwargs):
-    ds,c = partition(c, risinstance(dict))
+    ds,c = partition(c, risinstance(Mapping))
     for d in ds: kwargs = {**kwargs, **d}
     if ft_cls is None: ft_cls = fh_cfg.ft_cls
     if attrmap is None: attrmap=fh_cfg.attrmap

--- a/fasthtml/components.py
+++ b/fasthtml/components.py
@@ -19,7 +19,6 @@ __all__ = ['named', 'html_attrs', 'hx_attrs', 'hx_evts', 'js_evts', 'hx_attrs_an
 # %% ../nbs/api/01_components.ipynb
 from dataclasses import dataclass, asdict, is_dataclass, make_dataclass, replace, astuple, MISSING
 from bs4 import BeautifulSoup, Comment
-from collections import UserDict
 from typing import Literal, Mapping, Optional
 
 from fastcore.utils import *

--- a/nbs/api/01_components.ipynb
+++ b/nbs/api/01_components.ipynb
@@ -29,7 +29,6 @@
     "#| export\n",
     "from dataclasses import dataclass, asdict, is_dataclass, make_dataclass, replace, astuple, MISSING\n",
     "from bs4 import BeautifulSoup, Comment\n",
-    "from collections import UserDict\n",
     "from typing import Literal, Mapping, Optional\n",
     "\n",
     "from fastcore.utils import *\n",
@@ -51,6 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from collections import UserDict\n",
     "from lxml import html as lx\n",
     "from pprint import pprint"
    ]

--- a/nbs/api/01_components.ipynb
+++ b/nbs/api/01_components.ipynb
@@ -29,7 +29,8 @@
     "#| export\n",
     "from dataclasses import dataclass, asdict, is_dataclass, make_dataclass, replace, astuple, MISSING\n",
     "from bs4 import BeautifulSoup, Comment\n",
-    "from typing import Literal, Optional\n",
+    "from collections import UserDict\n",
+    "from typing import Literal, Mapping, Optional\n",
     "\n",
     "from fastcore.utils import *\n",
     "from fastcore.xml import *\n",
@@ -311,7 +312,7 @@
    "source": [
     "#| export\n",
     "def ft_html(tag: str, *c, id=None, cls=None, title=None, style=None, attrmap=None, valmap=None, ft_cls=None, **kwargs):\n",
-    "    ds,c = partition(c, risinstance(dict))\n",
+    "    ds,c = partition(c, risinstance(Mapping))\n",
     "    for d in ds: kwargs = {**kwargs, **d}\n",
     "    if ft_cls is None: ft_cls = fh_cfg.ft_cls\n",
     "    if attrmap is None: attrmap=fh_cfg.attrmap\n",
@@ -376,6 +377,26 @@
    "source": [
     "ft_html('a', {'@click.away':1})"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "979e9bc8614fb3c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "```html\n<a @click.away=\"1\"></a>\n```",
+      "text/plain": [
+       "a((),{'@click.away': 1})"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": "ft_html('a', UserDict({'@click.away':1}))"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
**Related Issue**
#737 

**Proposed Changes**

Dictionaries are allowed as a child of fasttags, which turns them into attributes. This change makes it so that any Mapping can be used for this, rather than just `dict`s. The purpose is to allow helpers to generate attributes that don't have to subclass the builtin `dict`.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
