### PR TITLE
add title= kwarg to fast_app() constructor

### DIFF
--- a/fasthtml/fastapp.py
+++ b/fasthtml/fastapp.py
@@ -36,6 +36,7 @@ def fast_app(
         middleware:Optional[tuple]=None, # Standard Starlette middleware
         live:bool=False, # Enable live reloading
         debug:bool=False, # Passed to Starlette, indicating if debug tracebacks should be returned on errors
+        title:str="FastHTML page", # Default page title
         routes:Optional[tuple]=None, # Passed to Starlette
         exception_handlers:Optional[dict]=None, # Passed to Starlette
         on_startup:Optional[callable]=None, # Passed to Starlette
@@ -67,7 +68,7 @@ def fast_app(
     h = (picolink,) if pico or (pico is None and default_hdrs) else ()
     if hdrs: h += tuple(hdrs)
 
-    app = _app_factory(hdrs=h, ftrs=ftrs, before=before, middleware=middleware, live=live, debug=debug, routes=routes, exception_handlers=exception_handlers,
+    app = _app_factory(hdrs=h, ftrs=ftrs, before=before, middleware=middleware, live=live, debug=debug, title=title, routes=routes, exception_handlers=exception_handlers,
                   on_startup=on_startup, on_shutdown=on_shutdown, lifespan=lifespan, default_hdrs=default_hdrs, secret_key=secret_key, canonical=canonical,
                   session_cookie=session_cookie, max_age=max_age, sess_path=sess_path, same_site=same_site, sess_https_only=sess_https_only,
                   sess_domain=sess_domain, key_fname=key_fname, exts=exts, surreal=surreal, htmx=htmx, htmlkw=htmlkw,


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] allow default title to be set from fast_app()'
labels: ''
assignees: ''

---

**Related Issue**
Please link to the issue that this pull request addresses. If there isn't one, please create an issue first.

https://github.com/AnswerDotAI/fasthtml/issues/485
(https://github.com/AnswerDotAI/fasthtml/pull/604)

**Proposed Changes**

This PR would add a `title=` kwarg to the `fast_app()` constructor, and have the effect of allowing a default page title to be set. It needn't do very much, because the underlying functionality was added to `FastHTML()` in #604 ; this PR just connects them.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x + NOTE] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**

- I confirmed that this works, by adding a `title='hello'` to the example from the docs here: https://www.fastht.ml/docs/#usage
- By declaring as `title:str="FastHTML page"` I have repeated that default from `FastHTML()`. This seemed simpler/less intrusive than declaring `title:Optional[str]=None`, and handling it downstream to avoid the DRY.
- AFAICT there are no docs or tests that would need to be updated for this.
- This `fast_app` call appears to exist outside the nbdev subset, and so if I'm not mistaken there it is appropriate to edit the python code in place.