### PR TITLE
Add --include_no_docstring

### DIFF
--- a/fasthtml/core.pyi
+++ b/fasthtml/core.pyi
@@ -1,6 +1,6 @@
 """The `FastHTML` subclass of `Starlette`, along with the `RouterX` and `RouteX` classes it automatically uses."""
-__all__ = ['empty', 'htmx_hdrs', 'fh_cfg', 'htmx_resps', 'htmx_exts', 'htmxsrc', 'fhjsscr', 'surrsrc', 'scopesrc', 'viewport', 'charset', 'cors_allow', 'iframe_scr', 'all_meths', 'devtools_loc', 'parsed_date', 'snake2hyphens', 'HtmxHeaders', 'HttpHeader', 'HtmxResponseHeaders', 'form2dict', 'parse_form', 'JSONResponse', 'flat_xt', 'Beforeware', 'EventStream', 'signal_shutdown', 'uri', 'decode_uri', 'flat_tuple', 'noop_body', 'respond', 'is_full_page', 'Redirect', 'get_key', 'qp', 'def_hdrs', 'FastHTML', 'nested_name', 'serve', 'Client', 'RouteFuncs', 'APIRouter', 'cookie', 'reg_re_param', 'MiddlewareBase', 'FtResponse', 'unqid', 'setup_ws']
-import json, uuid, inspect, types, signal, asyncio, threading, inspect, random
+__all__ = ['empty', 'htmx_hdrs', 'fh_cfg', 'htmx_resps', 'htmx_exts', 'htmxsrc', 'fhjsscr', 'surrsrc', 'scopesrc', 'viewport', 'charset', 'cors_allow', 'iframe_scr', 'all_meths', 'devtools_loc', 'parsed_date', 'snake2hyphens', 'HtmxHeaders', 'HttpHeader', 'HtmxResponseHeaders', 'form2dict', 'parse_form', 'JSONResponse', 'flat_xt', 'Beforeware', 'EventStream', 'signal_shutdown', 'uri', 'decode_uri', 'flat_tuple', 'noop_body', 'respond', 'is_full_page', 'Redirect', 'get_key', 'qp', 'def_hdrs', 'FastHTML', 'nested_name', 'serve', 'Client', 'RouteFuncs', 'APIRouter', 'cookie', 'reg_re_param', 'MiddlewareBase', 'FtResponse', 'unqid']
+import json, uuid, inspect, types, signal, asyncio, threading, inspect, random, contextlib
 from fastcore.utils import *
 from fastcore.xml import *
 from fastcore.meta import use_kwargs_dict
@@ -265,12 +265,18 @@ class FastHTML(Starlette):
         """Add a route at `path`"""
         ...
 
+    def set_lifespan(self, value):
+        ...
+
     def static_route_exts(self, prefix='/', static_path='.', exts='static'):
         """Add a static route at URL path `prefix` with files from `static_path` and `exts` defined by `reg_re_param()`"""
         ...
 
     def static_route(self, ext='', prefix='/', static_path='.'):
         """Add a static route at URL path `prefix` with files from `static_path` and single `ext` (including the '.')"""
+        ...
+
+    def setup_ws(app, f=noop):
         ...
 
     def devtools_json(self, path=None, uuid=None):
@@ -369,8 +375,5 @@ def unqid(seeded=False):
     ...
 
 def _add_ids(s):
-    ...
-
-def setup_ws(app, f=noop):
     ...
 devtools_loc = '/.well-known/appspecific/com.chrome.devtools.json'

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -3696,9 +3696,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/nbs/apilist.txt
+++ b/nbs/apilist.txt
@@ -7,6 +7,8 @@
     - `def __call__(self, scope, receive, send)`
     - `def authenticate(self, conn)`
 
+- `def user_pwd_auth(lookup, skip, **kwargs)`
+- `def basic_logout(request)`
 ## fasthtml.cli
 
 - `@call_parse def railway_link()`
@@ -19,6 +21,12 @@
 
 > `ft_html` and `ft_hx` functions to add some conveniences to `ft`, along with a full set of basic HTML components, and functions to work with forms and `FT` conversion
 
+- `@patch def __str__(self)`
+- `@patch def __radd__(self, b)`
+- `@patch def __add__(self, b)`
+- `def attrmap_x(o)`
+- `def ft_html(tag, *c, **kwargs)`
+- `@use_kwargs(hx_attrs + evt_attrs, keep=True) def ft_hx(tag, *c, **kwargs)`
 - `def File(fname)`
     Use the unescaped text in file `fname` directly
 
@@ -34,6 +42,7 @@
 - `def find_inputs(e, tags, **kw)`
     Recursively find all elements in `e` with `tags` and attrs matching `kw`
 
+- `def __getattr__(tag)`
 - `def html2ft(html, attr1st)`
     Convert HTML to an `ft` expression
 
@@ -80,6 +89,11 @@
 - `def EventStream(s)`
     Create a text/event-stream response from `s`
 
+- `def signal_shutdown()`
+- `def uri(_arg, **kwargs)`
+- `def decode_uri(s)`
+- `@patch def to_string(self, value)`
+- `@patch def url_path_for(self, name, **path_params)`
 - `def flat_tuple(o)`
     Flatten lists
 
@@ -89,12 +103,14 @@
 - `def respond(req, heads, bdy)`
     Default FT response creation function
 
+- `def is_full_page(req, resp)`
 - `class Redirect`
     Use HTMX or Starlette RedirectResponse as required to redirect to `loc`
 
     - `def __init__(self, loc)`
     - `def __response__(self, req)`
 
+- `def get_key(key, fname)`
 - `def qp(p, **kw)`
     Add parameters kw to path p
 
@@ -103,8 +119,8 @@
 
 - `class FastHTML`
     - `def __init__(self, debug, routes, middleware, title, exception_handlers, on_startup, on_shutdown, lifespan, hdrs, ftrs, exts, before, after, surreal, htmx, default_hdrs, sess_cls, secret_key, session_cookie, max_age, sess_path, same_site, sess_https_only, sess_domain, key_fname, body_wrap, htmlkw, nb_hdrs, canonical, **bodykw)`
-    - `def add_route(self, route)`
 
+- `@patch def add_route(self, route)`
 - `@patch def ws(self, path, conn, disconn, name, middleware)`
     Add a websocket route at `path`
 
@@ -114,6 +130,7 @@
 - `@patch def route(self, path, methods, name, include_in_schema, body_wrap)`
     Add a route at `path`
 
+- `@patch def set_lifespan(self, value)`
 - `def serve(appname, app, host, port, reload, reload_includes, reload_excludes)`
     Run the app in an async server, with live reload set as the default.
 
@@ -146,6 +163,7 @@
 - `def cookie(key, value, max_age, expires, path, domain, secure, httponly, samesite)`
     Create a 'set-cookie' `HttpHeader`
 
+- `def reg_re_param(m, s)`
 - `@patch def static_route_exts(self, prefix, static_path, exts)`
     Add a static route at URL path `prefix` with files from `static_path` and `exts` defined by `reg_re_param()`
 
@@ -161,6 +179,9 @@
     - `def __init__(self, content, status_code, headers, cls, media_type, background)`
     - `def __response__(self, req)`
 
+- `def unqid(seeded)`
+- `@patch def setup_ws(app, f)`
+- `@patch def devtools_json(self, path, uuid)`
 ## fasthtml.fastapp
 
 > The `fast_app` convenience wrapper
@@ -181,9 +202,11 @@
 - `def MarkdownJS(sel)`
     Implements browser-based markdown rendering.
 
+- `def KatexMarkdownJS(sel, inline_delim, display_delim, math_envs)`
 - `def HighlightJS(sel, langs, light, dark)`
     Implements browser-based syntax highlighting. Usage example [here](/tutorials/quickstart_for_web_devs.html#code-highlighting).
 
+- `def SortableJS(sel, ghost_class)`
 - `def MermaidJS(sel, theme)`
     Implements browser-based Mermaid diagram rendering.
 
@@ -203,6 +226,8 @@
 - `def wait_port_free(port, host, max_wait)`
     Wait for `port` to be free on `host`
 
+- `def render_ft()`
+- `def htmx_config_port(port)`
 - `class JupyUvi`
     Start and stop a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`
 
@@ -221,8 +246,11 @@
 - `def HTMX(path, app, host, port, height, link, iframe)`
     An iframe which displays the HTMX application in a notebook.
 
+- `def ws_client(app, nm, host, port, ws_connect, frame, link, **kwargs)`
 ## fasthtml.live_reload
 
+- `def LiveReloadJs(reload_attempts, reload_interval, **kwargs)`
+- `def live_reload_ws(websocket)`
 - `class FastHTMLWithLiveReload`
     `FastHTMLWithLiveReload` enables live reloading.
     This means that any code changes saved on the server will automatically
@@ -299,6 +327,7 @@
 - `@patch def retr_id(self, code, redirect_uri)`
     Call `retr_info` and then return id/subscriber value
 
+- `def url_match(url, patterns)`
 - `class OAuth`
     - `def __init__(self, app, cli, skip, redir_path, error_path, logout_path, login_path, https, http_patterns)`
     - `def redir_login(self, session)`
@@ -324,6 +353,7 @@
 
 > Basic components for generating Pico CSS tags
 
+- `def set_pico_cls()`
 - `@delegates(ft_hx, keep=True) def Card(*c, **kwargs)`
     A PicoCSS Card, implemented as an Article with optional Header and Footer
 
@@ -342,16 +372,7 @@
 - `@delegates(ft_hx, keep=True) def Container(*args, **kwargs)`
     A PicoCSS Container, implemented as a Main with class 'container'
 
-## fasthtml.stripe_otp
-
-- `def create_price(app_nm, amt, currency)`
-    Create a product and bind it to a price object. If product already exist just return the price list.
-
-- `def archive_price(app_nm)`
-    Archive a price - useful for cleanup if testing.
-
-- `class Payment`
-
+- `def PicoBusy()`
 ## fasthtml.svg
 
 > Simple SVG FT elements
@@ -424,6 +445,13 @@
 - `def SvgInb(*args, **kwargs)`
     Wraps an SVG shape as required for an HTMX inband swap
 
+## fasthtml.toaster
+
+- `def Toast(message, typ, dismiss, duration)`
+- `def add_toast(sess, message, typ, dismiss)`
+- `def render_toasts(sess)`
+- `def toast_after(resp, req, sess)`
+- `def setup_toasts(app, duration)`
 ## fasthtml.xtend
 
 > Simple extensions to standard HTML components, such as adding sensible defaults
@@ -488,6 +516,7 @@
 - `def run_js(js, id, **kw)`
     Run `js` script, auto-generating `id` based on name of caller if needed, and js-escaping any `kw` params
 
+- `def HtmxOn(eventname, code)`
 - `def jsd(org, repo, root, path, prov, typ, ver, esm, **kwargs)`
     jsdelivr `Script` or CSS `Link` tag, or URL
 
@@ -508,3 +537,5 @@
 - `def Favicon(light_icon, dark_icon)`
     Light and dark favicon headers
 
+- `def clear(id)`
+- `def with_sid(app, dest, path)`

--- a/nbs/llms-ctx-full.txt
+++ b/nbs/llms-ctx-full.txt
@@ -1531,7 +1531,7 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
 
 > The `fast_app` convenience wrapper
 
-- `def fast_app(db_file, render, hdrs, ftrs, tbls, before, middleware, live, debug, routes, exception_handlers, on_startup, on_shutdown, lifespan, default_hdrs, pico, surreal, htmx, exts, canonical, secret_key, key_fname, session_cookie, max_age, sess_path, same_site, sess_https_only, sess_domain, htmlkw, bodykw, reload_attempts, reload_interval, static_path, body_wrap, nb_hdrs, **kwargs)`
+- `def fast_app(db_file, render, hdrs, ftrs, tbls, before, middleware, live, debug, title, routes, exception_handlers, on_startup, on_shutdown, lifespan, default_hdrs, pico, surreal, htmx, exts, canonical, secret_key, key_fname, session_cookie, max_age, sess_path, same_site, sess_https_only, sess_domain, htmlkw, bodykw, reload_attempts, reload_interval, static_path, body_wrap, nb_hdrs, **kwargs)`
     Create a FastHTML or FastHTMLWithLiveReload app.
 
 ## fasthtml.js

--- a/nbs/llms-ctx.txt
+++ b/nbs/llms-ctx.txt
@@ -1531,7 +1531,7 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
 
 > The `fast_app` convenience wrapper
 
-- `def fast_app(db_file, render, hdrs, ftrs, tbls, before, middleware, live, debug, routes, exception_handlers, on_startup, on_shutdown, lifespan, default_hdrs, pico, surreal, htmx, exts, canonical, secret_key, key_fname, session_cookie, max_age, sess_path, same_site, sess_https_only, sess_domain, htmlkw, bodykw, reload_attempts, reload_interval, static_path, body_wrap, nb_hdrs, **kwargs)`
+- `def fast_app(db_file, render, hdrs, ftrs, tbls, before, middleware, live, debug, title, routes, exception_handlers, on_startup, on_shutdown, lifespan, default_hdrs, pico, surreal, htmx, exts, canonical, secret_key, key_fname, session_cookie, max_age, sess_path, same_site, sess_https_only, sess_domain, htmlkw, bodykw, reload_attempts, reload_interval, static_path, body_wrap, nb_hdrs, **kwargs)`
     Create a FastHTML or FastHTMLWithLiveReload app.
 
 ## fasthtml.js

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -2,5 +2,5 @@
 python tools/mk_pyi.py
 llms_txt2ctx nbs/llms.txt --optional true > nbs/llms-ctx-full.txt
 llms_txt2ctx nbs/llms.txt > nbs/llms-ctx.txt
-pysym2md --output_file nbs/apilist.txt fasthtml
+pysym2md --output_file nbs/apilist.txt fasthtml --include_no_docstring
 


### PR DESCRIPTION
We were running `pysym2md --output_file nbs/apilist.txt fasthtml` , by default pysym2md has `include_no_docstring:Param("Include symbols without docstrings?", store_true)=False,` so it was skipping functions like setup_ws which didn't have docstrings, and as a result they weren't showing up in apilist.txt.