### PR TITLE
Use data instead of json

### DIFF
--- a/fasthtml/oauth.py
+++ b/fasthtml/oauth.py
@@ -139,7 +139,7 @@ def parse_response(self:_AppClient, code, redirect_uri):
     "Get the token from the oauth2 server response"
     payload = dict(code=code, redirect_uri=redirect_uri, client_id=self.client_id,
                    client_secret=self.client_secret, grant_type='authorization_code')
-    r = httpx.post(self.token_url, json=payload)
+    r = httpx.post(self.token_url, data=payload)
     r.raise_for_status()
     self.parse_request_body_response(r.text)
 

--- a/nbs/api/08_oauth.ipynb
+++ b/nbs/api/08_oauth.ipynb
@@ -385,7 +385,7 @@
     "    \"Get the token from the oauth2 server response\"\n",
     "    payload = dict(code=code, redirect_uri=redirect_uri, client_id=self.client_id,\n",
     "                   client_secret=self.client_secret, grant_type='authorization_code')\n",
-    "    r = httpx.post(self.token_url, json=payload)\n",
+    "    r = httpx.post(self.token_url, data=payload)\n",
     "    r.raise_for_status()\n",
     "    self.parse_request_body_response(r.text)"
    ]


### PR DESCRIPTION
Fix OAuth2 token exchange to use form encoding instead of JSON

Changed httpx.post() to use `data=` instead of `json=` parameter to ensure 
requests are sent with `application/x-www-form-urlencoded` content type, 
as required by [RFC 6749 Section 4.1.3](https://tools.ietf.org/html/rfc6749#section-4.1.3) for OAuth2 token exchange endpoints.

This fixes authentication issues with Google OAuth2 and ensures compliance 
with other OAuth2 providers that strictly enforce the specification.