### PR TITLE
fix broken toasts

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -51,7 +51,7 @@ def add_toast(sess, message: str, typ: str = "info", dismiss: bool = False):
 
 def render_toasts(sess):
     toasts = [Toast(msg, typ, dismiss, sess['toast_duration']) for msg, typ, dismiss in sess.pop(sk, [])]
-    return Div(*toasts, hx_swap_oob=f'beforeend:#{tcid}')
+    return Div(*toasts, id=tcid, hx_swap_oob=f'beforeend:#{tcid}')
 
 def toast_after(resp, req, sess):
     if sk in sess and (not resp or isinstance(resp, (tuple,FT,FtResponse))):

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -131,7 +131,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2025, 9, 11, 14, 0)"
+       "datetime.datetime(2025, 9, 17, 14, 0)"
       ]
      },
      "execution_count": null,
@@ -2879,13 +2879,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Set to 2025-09-11 16:36:20.106162\n"
+      "Set to 2025-09-17 09:13:49.740165\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'Session time: 2025-09-11 16:36:20.106162'"
+       "'Session time: 2025-09-17 09:13:49.740165'"
       ]
      },
      "execution_count": null,
@@ -3109,10 +3109,29 @@
     "    add_toast(sess, tm, \"success\")\n",
     "    return P(\"I hate toast!\")\n",
     "\n",
-    "r = cli.get('/')\n",
-    "assert tm in r.text\n",
     "r = cli.get('/no-toast')\n",
-    "assert not tm in r.text"
+    "assert not tm in r.text\n",
+    "\n",
+    "r = cli.get('/')\n",
+    "assert tm in r.text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd0e4c06",
+   "metadata": {},
+   "source": [
+    "Here's a quick sanity check to confirm that toasts are rendered in the toast container correctly. See [issue](https://github.com/AnswerDotAI/fasthtml/issues/762)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2417e5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert 'id=\"fh-toast-container\"' in r.text"
    ]
   },
   {


### PR DESCRIPTION
**Related Issue**
#762 

**Proposed Changes**
This pr updates `render_toasts` so that toasts are always inserted into the toast container for regular page loads and htmx requests. The pr also includes a regression test.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
N/A
