### PR TITLE
Fix ft documentation in "from example" guide.

### DIFF
--- a/nbs/tutorials/by_example.ipynb
+++ b/nbs/tutorials/by_example.ipynb
@@ -2082,10 +2082,7 @@
    ]
   }
  ],
- "metadata": {
-  "solveit_dialog_mode": "learning",
-  "solveit_ver": 2
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
The current tutorial for ft tags says output can be 

```python
class Person:
    def __init__(self, name, age):
        self.name = name
        self.age = age

    def __ft__(self):
        return ['div', [f'{self.name} is {self.age} years old.'], {}]

p = Person('Jonathan', 28)
print(to_xml(Div(p, "more text", cls="container")))
```

Notice the list being returned by ft. I think this is not valid, so this is fixed in the docs.

Addresses confusion in #775