### PR TITLE
Bump toast z-index to 1090 so toasts appear above modals

### DIFF
--- a/fasthtml/toaster.py
+++ b/fasthtml/toaster.py
@@ -7,7 +7,7 @@ tcid='fh-toast-container'
 sk = "toasts"
 toast_css = """
 #fh-toast-container {
-    position: fixed; inset: 20px 0; z-index: 1000; max-width: 80vw;
+    position: fixed; inset: 20px 0; z-index: 1090; max-width: 80vw;
     display: flex; flex-direction: column; align-items: center;
     gap: 10px; pointer-events: none; margin: 0 auto;
 }


### PR DESCRIPTION
Toasts were using `z-index: 1000`, but UIkit modals (used by MonsterUI/FrankenUI) use `z-index: 1010`. This caused toasts to be hidden behind modals.

Bumped to `z-index: 1090` to ensure toasts always appear above modals while leaving room in the z-index scale for other elements.

Related: AnswerDotAI/MonsterUI#148, AnswerDotAI/solveit#1071