### PR TITLE
Fix incorrect description in Combining Routes docs

### DIFF
--- a/nbs/explains/routes.ipynb
+++ b/nbs/explains/routes.ipynb
@@ -287,7 +287,7 @@
     "\n",
     "Sometimes a FastHTML project can grow so weildy that putting all the routes into `main.py` becomes unweildy. Or, we install a FastHTML- or Starlette-based package that requires us to add routes. \n",
     "\n",
-    "First let's create a `books.py` module, that represents all the user-related views:"
+    "First let's create a `books.py` module containing the views for displaying books:"
    ]
   },
   {


### PR DESCRIPTION
The example creates a `books.py` module but the text described it as "user-related views". Updated to "views for displaying books" to match the actual example.

Fixes #799