### PR TITLE
Fix broken link to fastai coding style

### DIFF
--- a/nbs/explains/faq.ipynb
+++ b/nbs/explains/faq.ipynb
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "FastHTML coding style is the [fastai coding style](https://fast.ai/docs/dev/style.html). \n",
+    "FastHTML coding style is the [fastai coding style](https://docs.fast.ai/dev/style.html). \n",
     "\n",
     "If you are coming from a data science background the **fastai coding style** may already be your preferred style.\n",
     "\n",

--- a/nbs/llms-ctx-full.txt
+++ b/nbs/llms-ctx-full.txt
@@ -7058,7 +7058,7 @@ you can disable it entirely by adding this to your settings:
 ## Why the distinctive coding style?
 
 FastHTML coding style is the [fastai coding
-style](https://fast.ai/docs/dev/style.html).
+style](https://docs.fast.ai/dev/style.html).
 
 If you are coming from a data science background the **fastai coding
 style** may already be your preferred style.


### PR DESCRIPTION
The link to the fastai coding style guide was pointing to `fast.ai/docs/dev/style.html` which 404s. Updated to `docs.fast.ai/dev/style.html`.

Fixes #794