### PR TITLE
Add note about Post/Redirect/Get pattern in by_example tutorial

### DIFF
--- a/nbs/tutorials/by_example.ipynb
+++ b/nbs/tutorials/by_example.ipynb
@@ -682,6 +682,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "prg-note",
+   "metadata": {},
+   "source": [
+    "> **Note:** With traditional form submissions, refreshing the page after a POST will prompt \\\"Resubmit form data?\\\" — potentially causing duplicate entries. The standard fix is `return Redirect('/')` instead of `return home()`, known as the [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redirect/Get) pattern. With HTMX (covered next), this isn't needed since submissions happen via AJAX."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0e7066db",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Adds a brief note before the HTMX section explaining that refreshing after a POST can cause "Resubmit form data?" prompts, and that `Redirect('/')` is the traditional fix (the [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redirect/Get) pattern).

Also notes this isn't needed with HTMX since submissions happen via AJAX — which is a nice segue into why HTMX is useful.

Fixes #389