### PR TITLE
Fix live reload infinite loop on uvicorn >= 0.39

### DIFF
--- a/fasthtml/live_reload.py
+++ b/fasthtml/live_reload.py
@@ -1,4 +1,5 @@
 from starlette.routing import WebSocketRoute
+from starlette.websockets import WebSocketDisconnect
 from fasthtml.basics import FastHTML, Script
 
 __all__ = ["FastHTMLWithLiveReload"]
@@ -23,7 +24,11 @@ def LiveReloadJs(reload_attempts:int=20, reload_interval:int=1000, **kwargs):
     """
     return Script(src % (reload_attempts, reload_interval))
 
-async def live_reload_ws(websocket): await websocket.accept()
+async def live_reload_ws(websocket):
+    await websocket.accept()
+    try:
+        while True: await websocket.receive()
+    except WebSocketDisconnect: pass
 
 class FastHTMLWithLiveReload(FastHTML):
     """


### PR DESCRIPTION
## Summary
Fixes #817 — Live reload enters infinite page reload loop on uvicorn >= 0.39.

## The Problem
The `/live-reload` WebSocket handler was returning immediately after `accept()`. In uvicorn 0.39+, this correctly sends a close frame, which triggers the client's reconnect logic and causes an infinite reload loop.

## The Fix
Keep the WebSocket handler alive by looping on `receive()` until the client disconnects.

## Testing
- Reproduced the bug with uvicorn 0.40 and `fast_app(live=True)`
- Confirmed the fix stops the infinite reload loop
- Page now loads and stays stable