### PR TITLE
add optional client arg to HTMX for persistent tests

### DIFF
--- a/fasthtml/jupyter.py
+++ b/fasthtml/jupyter.py
@@ -118,7 +118,7 @@ from starlette.testclient import TestClient
 from html import escape
 
 # %% ../nbs/api/06_jupyter.ipynb #89b8984b
-def HTMX(path="/", host='localhost', app=None, port=8000, height="auto", link=False, iframe=True):
+def HTMX(path="/", host='localhost', app=None, port=8000, height="auto", link=False, iframe=True, client=None):
     "An iframe which displays the HTMX application in a notebook."
     if isinstance(height, int): height = f"{height}px"
     scr = """{
@@ -137,7 +137,8 @@ def HTMX(path="/", host='localhost', app=None, port=8000, height="auto", link=Fa
         route = f'/{unqid()}'
         res = path
         app.get(route)(lambda: res)
-        page = TestClient(app).get(route).text
+        cli = client if client is not None else TestClient(app)
+        page = cli.get(route).text
         src = f'srcdoc="{escape(page)}"'
     if iframe:
         return HTML(f'<iframe {src} style="width: 100%; height: {height}; border: none;" onload="{scr}" ' + """allow="accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking"></iframe> """)

--- a/nbs/api/06_jupyter.ipynb
+++ b/nbs/api/06_jupyter.ipynb
@@ -725,7 +725,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def HTMX(path=\"/\", host='localhost', app=None, port=8000, height=\"auto\", link=False, iframe=True):\n",
+    "def HTMX(path=\"/\", host='localhost', app=None, port=8000, height=\"auto\", link=False, iframe=True, client=None):\n",
     "    \"An iframe which displays the HTMX application in a notebook.\"\n",
     "    if isinstance(height, int): height = f\"{height}px\"\n",
     "    scr = \"\"\"{\n",
@@ -744,7 +744,8 @@
     "        route = f'/{unqid()}'\n",
     "        res = path\n",
     "        app.get(route)(lambda: res)\n",
-    "        page = TestClient(app).get(route).text\n",
+    "        cli = client if client is not None else TestClient(app)\n",
+    "        page = cli.get(route).text\n",
     "        src = f'srcdoc=\"{escape(page)}\"'\n",
     "    if iframe:\n",
     "        return HTML(f'<iframe {src} style=\"width: 100%; height: {height}; border: none;\" onload=\"{scr}\" ' + \"\"\"allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> \"\"\")"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,4 @@ include = ["fasthtml"]
 [tool.nbdev]
 jupyter_hooks = true
 custom_sidebar = false
+lib_path = "fasthtml"


### PR DESCRIPTION
When testing FastHTML apps with authentication in notebooks, the default HTMX function creates a fresh TestClient for each render. This means session cookies (like auth) don't persist, making it difficult to preview authenticated content. This change allows one to pass in an existing TestClient to use, allowing for preview of things that require session state.

Worked example: https://share.solve.it.com/d/d19bed2aa88ed7476a03b821a29caef7