### PR TITLE
Fix CSS syntax in by_example.ipynb

### DIFF
--- a/nbs/tutorials/by_example.ipynb
+++ b/nbs/tutorials/by_example.ipynb
@@ -576,7 +576,7 @@
    "outputs": [],
    "source": [
     "from fasthtml.common import *\n",
-    "css = Style(':root {--pico-font-size:90%,--pico-font-family: Pacifico, cursive;}') # <1>\n",
+    "css = Style(':root {--pico-font-size:90%;--pico-font-family: Pacifico, cursive;}') # <1>\n",
     "app = FastHTML(hdrs=(picolink, css)) # <2>\n",
     "\n",
     "@app.route(\"/\")\n",


### PR DESCRIPTION
An example of applying custom CSS in `by_example.ipynb` that adds a custom style tag to `hdrs` contains an errant comma where a semicolon should be used.  This prevents the custom font-family that's specified from actually being used when served to a browser.