### PR TITLE
fix: allow serve() to detect any entry point function name

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -714,10 +714,9 @@ def serve(
     "Run the app in an async server, with live reload set as the default."
     bk = inspect.currentframe().f_back
     glb = bk.f_globals
-    code = bk.f_code
     if not appname:
         if glb.get('__name__')=='__main__': appname = Path(glb.get('__file__', '')).stem
-        elif code.co_name=='main' and bk.f_back.f_globals.get('__name__')=='__main__': appname = inspect.getmodule(bk).__name__
+        elif bk.f_back.f_globals.get('__name__')=='__main__': appname = inspect.getmodule(bk).__name__
     import uvicorn
     if appname:
         if not port: port=int(os.getenv("PORT", default=5001))


### PR DESCRIPTION
Fixes #816.

The `serve()` function previously required the calling function to be named exactly `'main'`. This restriction is unnecessary since the key check is whether we're running from `__main__`, not the function name.

**Before:** Entry points like `myapp:start_app` would fail silently.

**After:** Any function name works as long as it's called from `__main__`.

Changes:
- Removed the `code.co_name=='main'` check from appname detection
- Removed unused `code` variable