### PR TITLE
fix: pass indent as keyword arg in _to_xml call

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -368,7 +368,7 @@ def _to_xml(req, resp, indent):
     "Convert response to XML string with target URL resolution"
     resp = _apply_ft(resp)
     _find_targets(req, resp)
-    return to_xml(resp, indent)
+    return to_xml(resp, indent=indent)
 
 # %% ../nbs/api/00_core.ipynb #f1e3ed2d
 _iter_typs = (tuple,list,map,filter,range,types.GeneratorType)

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1238,7 +1238,7 @@
     "    \"Convert response to XML string with target URL resolution\"\n",
     "    resp = _apply_ft(resp)\n",
     "    _find_targets(req, resp)\n",
-    "    return to_xml(resp, indent)"
+    "    return to_xml(resp, indent=indent)"
    ]
   },
   {
@@ -4288,7 +4288,10 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "solveit_dialog_mode": "learning",
+  "solveit_ver": 2
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] Fix: pass indent as keyword arg in _to_xml call'
labels: ''
assignees: ''

---

**Related Issue**
No existing issue. `fh_cfg.indent` being `True` causes `TypeError: sequence item 1: expected str instance, bool found` when rendering any route.

**Proposed Changes**
In `fasthtml/core.py` line 371, `indent` is passed as a positional argument to `to_xml()`. Since `to_xml` uses `*elms`, this causes `indent` to be treated as an HTML element to render. Changed to `indent=indent` (keyword argument).

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
The bug occurs when `fh_cfg.indent` is set to `True` (boolean). The `to_xml(*elms, ...)` signature captures it as an element, then `'\n'.join(...)` fails because it encounters a `bool` instead of a string.