### PR TITLE
fix: make `_handle` param `f` positional-only to avoid kwarg conflict

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -254,7 +254,7 @@ class Beforeware:
     def __init__(self, f, skip=None): self.f,self.skip = f,skip or []
 
 # %% ../nbs/api/00_core.ipynb #78c3c357
-async def _handle(f, *args, **kwargs):
+async def _handle(f, /, *args, **kwargs):
     return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)
 
 # %% ../nbs/api/00_core.ipynb #ad0f0e87

--- a/fasthtml/core.pyi
+++ b/fasthtml/core.pyi
@@ -122,7 +122,7 @@ class Beforeware:
     def __init__(self, f, skip=None):
         ...
 
-async def _handle(f, args, **kwargs):
+async def _handle(f, /, args, **kwargs):
     ...
 
 def _find_wsp(ws, data, hdrs, arg: str, p: Parameter):

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -679,7 +679,7 @@
    "id": "abfc3145",
    "metadata": {},
    "source": [
-    "Routes often need to return different responses depending on whether the request comes from a browser or an API client. The `api:ApiReturn` parameter handles this automatically — add it to any route signature and call it with two arguments: the API response and the browser response. If the request's `Accept` header is `application/json` then a dict of the kwargs is returned, otherwise, the first value is returned. For example, `return api(Redirect('/records'), id=record.id)` returns {'id':id} for API callers and a redirect for the browser. This keeps your route logic in one place instead of splitting it across separate endpoints."
+    "Routes often need to return different responses depending on whether the request comes from a browser or an API client. The `api:ApiReturn` parameter handles this automatically \u2014 add it to any route signature and call it with two arguments: the API response and the browser response. If the request's `Accept` header is `application/json` then a dict of the kwargs is returned, otherwise, the first value is returned. For example, `return api(Redirect('/records'), id=record.id)` returns {'id':id} for API callers and a redirect for the browser. This keeps your route logic in one place instead of splitting it across separate endpoints."
    ]
   },
   {
@@ -1039,7 +1039,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "async def _handle(f, *args, **kwargs):\n",
+    "async def _handle(f, /, *args, **kwargs):\n",
     "    return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)"
    ]
   },


### PR DESCRIPTION
Closes #834

## Summary

When a POST route handler takes `f` as a form-data parameter, `_handle(f, **wreq)` raises:
```
TypeError: _handle() got multiple values for argument 'f'
```
because `wreq` contains `f` from the form data while `f` is also passed positionally as the handler function.

### Fix

Add `/` after `f` in `_handle`'s signature to make it positional-only:
```python
async def _handle(f, /, *args, **kwargs):
```

This is the standard Python pattern for functions that forward `**kwargs` (see `functools.partial`, `functools.reduce`, etc.). The `f` parameter can only be passed positionally, so `f=<value>` in `**kwargs` no longer conflicts.

Updated both the notebook source (`nbs/api/00_core.ipynb`) and generated files (`core.py`, `core.pyi`).

> AI-assisted testing, AI-assisted review