### PR TITLE
Fix Starlette 1.0 compatibility: convert on_startup/on_shutdown to lifespan

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -574,10 +574,12 @@ def _wrap_lifespan(lifespan, on_startup, on_shutdown):
     @contextlib.asynccontextmanager
     async def _lifespan(app):
         for h in on_startup: await h() if inspect.iscoroutinefunction(h) else h()
-        if lifespan:
-            async with lifespan(app) as state: yield state
-        else: yield
-        for h in on_shutdown: await h() if inspect.iscoroutinefunction(h) else h()
+        try:
+            if lifespan:
+                async with lifespan(app) as state: yield state
+            else: yield
+        finally:
+            for h in on_shutdown: await h() if inspect.iscoroutinefunction(h) else h()
     return _lifespan
 
 # %% ../nbs/api/00_core.ipynb #3327a1e9

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1730,10 +1730,12 @@
     "    @contextlib.asynccontextmanager\n",
     "    async def _lifespan(app):\n",
     "        for h in on_startup: await h() if inspect.iscoroutinefunction(h) else h()\n",
-    "        if lifespan:\n",
-    "            async with lifespan(app) as state: yield state\n",
-    "        else: yield\n",
-    "        for h in on_shutdown: await h() if inspect.iscoroutinefunction(h) else h()\n",
+    "        try:\n",
+    "            if lifespan:\n",
+    "                async with lifespan(app) as state: yield state\n",
+    "            else: yield\n",
+    "        finally:\n",
+    "            for h in on_shutdown: await h() if inspect.iscoroutinefunction(h) else h()\n",
     "    return _lifespan"
    ]
   },

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -58,3 +58,19 @@ def test_async_startup_shutdown():
     with cli:
         assert state == ['async_start']
     assert state == ['async_start', 'async_stop']
+
+def test_shutdown_runs_on_lifespan_error():
+    state = []
+    @contextlib.asynccontextmanager
+    async def lifespan(app):
+        yield
+        raise RuntimeError('lifespan error')
+    app = FastHTML(
+        lifespan=lifespan,
+        on_shutdown=[lambda: state.append('shutdown')],
+    )
+    cli = TestClient(app, raise_server_exceptions=False)
+    try:
+        with cli: pass
+    except RuntimeError: pass
+    assert state == ['shutdown']


### PR DESCRIPTION
**Related Issue**
Fixes #847

**Proposed Changes**
Starlette 1.0 removed `on_startup`/`on_shutdown` params from `Starlette.__init__()`. This adds `_wrap_lifespan()` to convert these callbacks into a lifespan context manager. Unlike #848, this composes with any user-provided `lifespan` instead of silently dropping the callbacks.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Closes #848's approach by composing `on_startup`/`on_shutdown` with `lifespan` rather than prioritizing one over the other. Also uses `inspect.iscoroutinefunction` instead of the deprecated `asyncio.iscoroutinefunction`.
