### PR TITLE
Fix ws header lookup key mismatch

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -267,7 +267,7 @@ async def _handle(f, *args, **kwargs):
 
 # %% ../nbs/api/00_core.ipynb #ad0f0e87
 async def _wrap_ws(ws, data, params):
-    hdrs = {k.lower().replace('-','_'):v for k,v in data.pop('HEADERS', {}).items()}
+    hdrs = Headers({k.lower():v for k,v in data.pop('HEADERS', {}).items()})
     return await _find_ps(ws, data, hdrs, params)
 
 # %% ../nbs/api/00_core.ipynb #dcc15129

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -132,10 +132,10 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2026, 3, 24, 14, 0)"
+       "datetime.datetime(2026, 3, 27, 14, 0)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -156,7 +156,7 @@
        "True"
       ]
      },
-     "execution_count": null,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,7 +191,7 @@
        "'Snake-Case'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -261,7 +261,7 @@
        "HtmxHeaders(boosted=None, current_url=None, history_restore_request=None, prompt=None, request='1', target=None, trigger_name=None, trigger=None)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -428,7 +428,7 @@
        "'HX-Trigger-After-Settle'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -464,7 +464,7 @@
        "HttpHeader(k='HX-Trigger-After-Settle', v='hi')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -499,7 +499,7 @@
        "{'a': int, 'b': str}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -522,7 +522,7 @@
        "{'x': str, 'y': str}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -672,7 +672,7 @@
        "Foo(d={'a': 1})"
       ]
      },
-     "execution_count": null,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -762,7 +762,7 @@
        "\"['1', '2']\""
       ]
      },
-     "execution_count": null,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -894,7 +894,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'req': <starlette.requests.Request object>, 'this': <starlette.applications.Starlette object>, 'a': '1', 'b': HttpHeader(k='value1', v='value3'), 'state': <starlette.datastructures.State object>}\n"
+      "{'req': <starlette.requests.Request object at 0x78026faa9ee0>, 'this': <starlette.applications.Starlette object at 0x78026fa67170>, 'a': '1', 'b': HttpHeader(k='value1', v='value3'), 'state': <starlette.datastructures.State object at 0x78026faa8ad0>}\n"
      ]
     }
    ],
@@ -920,7 +920,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'req': <starlette.requests.Request object>, 'this': <starlette.applications.Starlette object>, 'a': '1', 'b': HttpHeader(k='value1', v='value3')}\n"
+      "{'req': <starlette.requests.Request object at 0x78026faaaff0>, 'this': <starlette.applications.Starlette object at 0x78026faa95e0>, 'a': '1', 'b': HttpHeader(k='value1', v='value3')}\n"
      ]
     }
    ],
@@ -962,7 +962,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'req': <starlette.requests.Request object>, 'this': <starlette.applications.Starlette object>, 'a': ''}\n"
+      "{'req': <starlette.requests.Request object at 0x78026faabad0>, 'this': <starlette.applications.Starlette object at 0x78026faaaae0>, 'a': ''}\n"
      ]
     }
    ],
@@ -1083,7 +1083,7 @@
    "source": [
     "#| export\n",
     "async def _wrap_ws(ws, data, params):\n",
-    "    hdrs = {k.lower().replace('-','_'):v for k,v in data.pop('HEADERS', {}).items()}\n",
+    "    hdrs = Headers({k.lower():v for k,v in data.pop('HEADERS', {}).items()})\n",
     "    return await _find_ps(ws, data, hdrs, params)"
    ]
   },
@@ -1137,6 +1137,21 @@
     "    ws.send_text('{\"msg\":\"Hi!\"}')\n",
     "    data = ws.receive_text()\n",
     "    assert data == 'Message text was: Hi!', data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bda2e425",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def on_receive(hx_trigger:str): return f\"trigger: {hx_trigger}\"\n",
+    "cli = TestClient(Starlette(routes=[WebSocketRoute('/', _ws_endp(on_receive))]))\n",
+    "with cli.websocket_connect('/') as ws:\n",
+    "    ws.send_text(json.dumps({\"HEADERS\": {\"Hx-Trigger\": \"my-btn\"}}))\n",
+    "    data = ws.receive_text()\n",
+    "    assert data == 'trigger: my-btn', data\n"
    ]
   },
   {
@@ -4296,7 +4311,10 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "solveit_dialog_mode": "learning",
+  "solveit_ver": 2
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
https://github.com/AnswerDotAI/fasthtml/issues/852
**Proposed Changes**
Fixes https://github.com/AnswerDotAI/fasthtml/issues/852

In `_wrap_ws`, replace the plain dict with Starlette's Headers and keep hyphenated keys instead of converting to underscores. This makes WS headers behave the same as HTTP headers, so `_find_p`'s `snake2hyphens` lookup works correctly.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

I also added a new test related to this in the nb:
```python
def on_receive(hx_trigger:str): return f"trigger: {hx_trigger}"
cli = TestClient(Starlette(routes=[WebSocketRoute('/', _ws_endp(on_receive))]))
with cli.websocket_connect('/') as ws:
    ws.send_text(json.dumps({"HEADERS": {"Hx-Trigger": "my-btn"}}))
    data = ws.receive_text()
    assert data == 'trigger: my-btn', data
```

@jph00 