### PR TITLE
Fix WebSocket crash when HTMX sends null header values

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -267,7 +267,7 @@ async def _handle(f, *args, **kwargs):
 
 # %% ../nbs/api/00_core.ipynb #ad0f0e87
 async def _wrap_ws(ws, data, params):
-    hdrs = Headers({k.lower():v for k,v in data.pop('HEADERS', {}).items()})
+    hdrs = Headers({k.lower():v for k,v in data.pop('HEADERS', {}).items() if v is not None})
     return await _find_ps(ws, data, hdrs, params)
 
 # %% ../nbs/api/00_core.ipynb #dcc15129

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1083,7 +1083,7 @@
    "source": [
     "#| export\n",
     "async def _wrap_ws(ws, data, params):\n",
-    "    hdrs = Headers({k.lower():v for k,v in data.pop('HEADERS', {}).items()})\n",
+    "    hdrs = Headers({k.lower():v for k,v in data.pop('HEADERS', {}).items() if v is not None})\n",
     "    return await _find_ps(ws, data, hdrs, params)"
    ]
   },


### PR DESCRIPTION
**Related Issue**
Fixes #855

**Proposed Changes**
Filter out `None` values before constructing Starlette `Headers()` in `_wrap_ws` (`core.py:270`). This fixes the `AttributeError: 'NoneType' object has no attribute 'encode'` crash that occurs when HTMX's WebSocket extension sends `null` header values (e.g. `HX-Trigger: null`).

```python
# Before
hdrs = Headers({k.lower():v for k,v in data.pop('HEADERS', {}).items()})

# After
hdrs = Headers({k.lower():v for k,v in data.pop('HEADERS', {}).items() if v is not None})
```

This preserves the case-insensitive header lookup behavior introduced in #853 while gracefully handling `null` values.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Regression introduced in #853 (commit d17be3c). The fix for #852 correctly switched from a plain dict to Starlette `Headers()` for case-insensitive lookup, but missed that HTMX sends `null` values for headers like `HX-Trigger` and `HX-Trigger-Name` when there is no triggering element. Starlette's `Headers()` constructor calls `.encode("latin-1")` on every value, which raises `AttributeError` on `None`.