### PR TITLE
fix: prevent query params leaking into typed session dict

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -198,6 +198,7 @@ async def _find_p(conn, data, hdrs, arg:str, p:Parameter):
         if issubclass(anno, Starlette): return conn.scope['app']
         if issubclass(anno, HTTPConnection): return conn
         if issubclass(anno, State): return conn.scope['app'].state
+        if 'session'.startswith(arg.lower()) and anno is dict: return conn.scope.get('session', {})
         if anno is dict: return data
         if _is_body(anno):
             if 'session'.startswith(arg.lower()): return conn.scope.get('session', {})

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -790,6 +790,7 @@
     "        if issubclass(anno, Starlette): return conn.scope['app']\n",
     "        if issubclass(anno, HTTPConnection): return conn\n",
     "        if issubclass(anno, State): return conn.scope['app'].state\n",
+    "        if 'session'.startswith(arg.lower()) and anno is dict: return conn.scope.get('session', {})\n",
     "        if anno is dict: return data\n",
     "        if _is_body(anno):\n",
     "            if 'session'.startswith(arg.lower()): return conn.scope.get('session', {})\n",

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -46,9 +46,11 @@ def test_ft_response():
     assert 'Toast FtResponse' in res.text
 
 def test_get_toaster_with_typehint():
+    cli.get('/set-toast-get', follow_redirects=False)
     res = cli.get('/see-toast-with-typehint', follow_redirects=False)
     assert 'Toast get' in res.text
 
+    cli.get('/set-toast-get', follow_redirects=False)
     res = cli.get('/see-toast-with-typehint', follow_redirects=True)
     assert 'Toast get' in res.text
 


### PR DESCRIPTION
## Summary

Fixes #845. Replaces #854 (closed — was editing `.py` directly instead of the nbdev notebook).

When a session parameter is type-hinted as `dict`, query parameters leak into the session because `if anno is dict: return data` in `_find_p` fires before the session name check. Since `_find_ps` merges query params into `data`, this returns contaminated data instead of the actual session.

## Fix

Add a session name check before `anno is dict` in `_find_p` (in `nbs/api/00_core.ipynb` Cell 47):

```python
if 'session'.startswith(arg.lower()) and anno is dict: return conn.scope.get('session', {})
if anno is dict: return data
```

One line, same pattern used throughout `_find_p`.

## Changes

- `nbs/api/00_core.ipynb` — source notebook fix
- `fasthtml/core.py` — regenerated from notebook
- `tests/test_toaster.py` — `test_get_toaster_with_typehint` now sets a toast before checking the typed endpoint

## Test plan

- [x] `test_get_toaster_with_typehint` passes (was failing on main)
- [x] All 5 tests in `test_toaster.py` pass
- [x] No regressions — other `dict`-annotated params still get `data`