### PR TITLE
fix: make _handle parameter f positional-only to avoid form field collision

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -266,7 +266,7 @@ class Beforeware:
     def __repr__(self): return f'Beforeware({self.f}, skip={self.skip})'
 
 # %% ../nbs/api/00_core.ipynb #78c3c357
-async def _handle(f, *args, **kwargs):
+async def _handle(f, /, *args, **kwargs):
     return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)
 
 # %% ../nbs/api/00_core.ipynb #ad0f0e87

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1121,7 +1121,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "async def _handle(f, *args, **kwargs):\n",
+    "async def _handle(f, /, *args, **kwargs):\n",
     "    return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)"
    ]
   },

--- a/tests/test_handle_param_conflict.py
+++ b/tests/test_handle_param_conflict.py
@@ -1,0 +1,30 @@
+"""Regression test for #834: _handle() conflicts with form field named 'f'."""
+from fasthtml.common import *
+from starlette.testclient import TestClient
+
+app, rt = fast_app()
+
+@rt('/upload', methods=['POST'])
+def upload(f: str):
+    return f'Got: {f}'
+
+@rt('/multi', methods=['POST'])
+def multi(f: str, g: str):
+    return f'{f},{g}'
+
+cli = TestClient(app)
+
+def test_form_field_named_f():
+    """POST with form field 'f' must not crash with 'got multiple values for argument f'."""
+    res = cli.post('/upload', data={'f': 'hello'})
+    assert res.status_code == 200
+    assert 'hello' in res.text
+
+def test_form_field_named_f_with_others():
+    """POST with form field 'f' alongside other fields."""
+    res = cli.post('/multi', data={'f': 'a', 'g': 'b'})
+    assert res.status_code == 200
+    assert 'a,b' in res.text
+
+test_form_field_named_f()
+test_form_field_named_f_with_others()


### PR DESCRIPTION
**Related Issue**
Fixes #834

**Proposed Changes**
`_handle(f, *args, **kwargs)` uses `f` as both the handler function (positional) and a potential form field name (via `**kwargs`). When a POST route accepts a field named `f`, the call `_handle(f, **wreq)` at `core.py:481` passes `f` twice, causing `TypeError: _handle() got multiple values for argument 'f'`.

The fix adds `/` after `f` to make it positional-only: `async def _handle(f, /, *args, **kwargs)`. This is the standard Python pattern used by `functools.partial`, `functools.reduce`, and similar stdlib functions to prevent name collisions with forwarded keyword arguments.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
- Previous PR #840 attempted the same fix but was withdrawn by its author.
- The regression test confirms the fix: `pytest tests/test_handle_param_conflict.py -v`