### PR TITLE
allow multiple route before functions

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -20,7 +20,7 @@ from fastcore.meta import use_kwargs_dict,delegates
 from fastcore.style import S
 
 from types import UnionType, SimpleNamespace as ns, GenericAlias
-from typing import get_args, get_origin, Union, Mapping, List, Any
+from typing import get_args, get_origin, Union, Mapping, List, Any, Callable
 from datetime import datetime,date
 from dataclasses import dataclass
 from inspect import Parameter,get_annotations
@@ -664,7 +664,7 @@ all_meths = 'get post put delete patch head trace options'.split()
 
 # %% ../nbs/api/00_core.ipynb #26b147ba
 @patch
-def _endp(self:FastHTML, f, body_wrap, before=None):
+def _endp(self:FastHTML, f, body_wrap, before:Optional[Callable|tuple]=None):
     "Create endpoint wrapper with before/after middleware processing"
     sig = signature_ex(f, True)
     for n,p in sig.parameters.items(): (msg:=_check_anno(n,p.annotation)) and warn(msg)
@@ -679,7 +679,8 @@ def _endp(self:FastHTML, f, body_wrap, before=None):
                 else: bf,skip = b,[]
                 if not any(re.fullmatch(r, req.url.path) for r in skip):
                     resp = await _wrap_call(bf, req, _params(bf))
-        if not resp and before: resp = await _wrap_call(before, req, _params(before))
+        for b in listify(before):
+            if not resp: resp = await _wrap_call(b, req, _params(b))
         req.body_wrap = body_wrap
         if not resp: resp = await _wrap_call(f, req, sig.parameters)
         for a in self.after:
@@ -734,7 +735,7 @@ def nested_name(f):
 
 # %% ../nbs/api/00_core.ipynb #72760b09
 @patch
-def _add_route(self:FastHTML, func, path, methods, name, include_in_schema, body_wrap, host=None, before=None):
+def _add_route(self:FastHTML, func, path, methods, name, include_in_schema, body_wrap, host=None, before:Optional[Callable|tuple]=None):
     "Add HTTP route to FastHTML app with automatic method detection"
     n,fn,p = name,nested_name(func),None if callable(path) else path
     if methods: m = [methods] if isinstance(methods,str) else methods
@@ -751,7 +752,7 @@ def _add_route(self:FastHTML, func, path, methods, name, include_in_schema, body
 
 # %% ../nbs/api/00_core.ipynb #f5cb2c2b
 @patch
-def route(self:FastHTML, path:str=None, methods=None, name=None, include_in_schema=True, body_wrap=None, host=None, before=None):
+def route(self:FastHTML, path:str=None, methods=None, name=None, include_in_schema=True, body_wrap=None, host=None, before:Optional[Callable|tuple]=None):
     "Add a route at `path`"
     def f(func):
         return self._add_route(func, path, methods, name=name, include_in_schema=include_in_schema, body_wrap=body_wrap, host=host, before=before)

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -51,7 +51,7 @@
     "from fastcore.style import S\n",
     "\n",
     "from types import UnionType, SimpleNamespace as ns, GenericAlias\n",
-    "from typing import get_args, get_origin, Union, Mapping, List, Any\n",
+    "from typing import get_args, get_origin, Union, Mapping, List, Any, Callable\n",
     "from datetime import datetime,date\n",
     "from dataclasses import dataclass\n",
     "from inspect import Parameter,get_annotations\n",
@@ -1966,7 +1966,7 @@
    "source": [
     "#| export\n",
     "@patch\n",
-    "def _endp(self:FastHTML, f, body_wrap, before=None):\n",
+    "def _endp(self:FastHTML, f, body_wrap, before:Optional[Callable|tuple]=None):\n",
     "    \"Create endpoint wrapper with before/after middleware processing\"\n",
     "    sig = signature_ex(f, True)\n",
     "    for n,p in sig.parameters.items(): (msg:=_check_anno(n,p.annotation)) and warn(msg)\n",
@@ -1981,7 +1981,8 @@
     "                else: bf,skip = b,[]\n",
     "                if not any(re.fullmatch(r, req.url.path) for r in skip):\n",
     "                    resp = await _wrap_call(bf, req, _params(bf))\n",
-    "        if not resp and before: resp = await _wrap_call(before, req, _params(before))\n",
+    "        for b in listify(before):\n",
+    "            if not resp: resp = await _wrap_call(b, req, _params(b))\n",
     "        req.body_wrap = body_wrap\n",
     "        if not resp: resp = await _wrap_call(f, req, sig.parameters)\n",
     "        for a in self.after:\n",
@@ -2118,7 +2119,7 @@
    "source": [
     "#| export\n",
     "@patch\n",
-    "def _add_route(self:FastHTML, func, path, methods, name, include_in_schema, body_wrap, host=None, before=None):\n",
+    "def _add_route(self:FastHTML, func, path, methods, name, include_in_schema, body_wrap, host=None, before:Optional[Callable|tuple]=None):\n",
     "    \"Add HTTP route to FastHTML app with automatic method detection\"\n",
     "    n,fn,p = name,nested_name(func),None if callable(path) else path\n",
     "    if methods: m = [methods] if isinstance(methods,str) else methods\n",
@@ -2143,7 +2144,7 @@
    "source": [
     "#| export\n",
     "@patch\n",
-    "def route(self:FastHTML, path:str=None, methods=None, name=None, include_in_schema=True, body_wrap=None, host=None, before=None):\n",
+    "def route(self:FastHTML, path:str=None, methods=None, name=None, include_in_schema=True, body_wrap=None, host=None, before:Optional[Callable|tuple]=None):\n",
     "    \"Add a route at `path`\"\n",
     "    def f(func):\n",
     "        return self._add_route(func, path, methods, name=name, include_in_schema=include_in_schema, body_wrap=body_wrap, host=host, before=before)\n",
@@ -3520,6 +3521,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b9fdbdd8",
+   "metadata": {},
+   "source": [
+    "A route-level `before` can set session data, short-circuit with a response, or raise to block access:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "f94ea388",
@@ -3539,6 +3548,58 @@
     "test_eq(cli.get('/dashboard?user=admin').text, 'bar')\n",
     "test_eq(cli.get('/dashboard?user=guest').text, 'guest view')\n",
     "test_eq(cli.get('/dashboard?user=other').status_code, 403)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35615416",
+   "metadata": {},
+   "source": [
+    "Multiple `before` functions run in order, each receiving the injected request params:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b751acb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def set_a(sess): sess['a'] = 1\n",
+    "def set_b(sess): sess['b'] = 2\n",
+    "\n",
+    "@rt('/multi', before=(set_a, set_b))\n",
+    "def get(sess): return f\"{sess.get('a')},{sess.get('b')}\"\n",
+    "\n",
+    "test_eq(cli.get('/multi').text, '1,2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49cc8791",
+   "metadata": {},
+   "source": [
+    "A truthy return from any `before` becomes the response; remaining `before`s and the handler are skipped (return `None` to continue):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83188ab0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calls = []\n",
+    "def first(sess): \n",
+    "    calls.append('first')\n",
+    "    return 'stop'\n",
+    "def second(sess): calls.append('second')\n",
+    "\n",
+    "@rt('/chain', before=(first, second))\n",
+    "def get(sess): return 'handler'\n",
+    "\n",
+    "test_eq(cli.get('/chain').text, 'stop')\n",
+    "test_eq(calls, ['first'])"
    ]
   },
   {


### PR DESCRIPTION
**Proposed Changes**
Allow multiple before functions in a route so you can do things like 

```py
@rt(before=(check_user, limit('20/d'))
def index(sess): ...
```

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
