### PR TITLE
Use @threaded in JupyUvi

### DIFF
--- a/fasthtml/jupyter.py
+++ b/fasthtml/jupyter.py
@@ -13,7 +13,7 @@ from fastcore.utils import *
 from fastcore.meta import delegates
 from .common import *
 from .common import show as _show
-from fastcore.parallel import startthread
+from fastcore.parallel import threaded
 try: from IPython.display import HTML,Markdown,display
 except ImportError: pass
 
@@ -21,8 +21,9 @@ except ImportError: pass
 def nb_serve(app, log_level="error", port=8000, host='0.0.0.0', daemon=False, **kwargs):
     "Start a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`; use `daemon=True` for notebook tests so failed runs don't block process shutdown"
     server = uvicorn.Server(uvicorn.Config(app, log_level=log_level, host=host, port=port, **kwargs))
-    server.thread = Thread(target=lambda: asyncio.run(server.serve()), daemon=daemon)
-    server.thread.start()
+    @threaded(daemon=daemon)
+    def run_server(): asyncio.run(server.serve())
+    run_server()
     while not server.started: time.sleep(0.01)
     return server
 
@@ -82,7 +83,7 @@ document.body.addEventListener('htmx:configRequest', (event) => {
 # %% ../nbs/api/06_jupyter.ipynb #29a834a5
 class JupyUvi:
     "Start and stop a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`"
-    def __init__(self, app, log_level="error", host='0.0.0.0', port=8000, start=True, **kwargs):
+    def __init__(self, app, log_level="error", host='0.0.0.0', port=8000, start=True, daemon=False, **kwargs):
         self.kwargs = kwargs
         store_attr(but='start')
         self.server = None
@@ -90,14 +91,13 @@ class JupyUvi:
         if not os.environ.get('IN_SOLVEIT'): htmx_config_port(port)
 
     def start(self):
-        self.server = nb_serve(self.app, log_level=self.log_level, host=self.host, port=self.port, **self.kwargs)
+        self.server = nb_serve(self.app, log_level=self.log_level, host=self.host, port=self.port,daemon=self.daemon, **self.kwargs)
 
     async def start_async(self):
         self.server = await nb_serve_async(self.app, log_level=self.log_level, host=self.host, port=self.port, **self.kwargs)
 
     def stop(self):
         self.server.should_exit = True
-        if hasattr(self.server, 'thread'): self.server.thread.join(timeout=3)
         wait_port_free(self.port)
 
 

--- a/fasthtml/jupyter.py
+++ b/fasthtml/jupyter.py
@@ -13,7 +13,7 @@ from fastcore.utils import *
 from fastcore.meta import delegates
 from .common import *
 from .common import show as _show
-from fastcore.parallel import threaded
+from fastcore.parallel import startthread
 try: from IPython.display import HTML,Markdown,display
 except ImportError: pass
 
@@ -21,9 +21,8 @@ except ImportError: pass
 def nb_serve(app, log_level="error", port=8000, host='0.0.0.0', daemon=False, **kwargs):
     "Start a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`; use `daemon=True` for notebook tests so failed runs don't block process shutdown"
     server = uvicorn.Server(uvicorn.Config(app, log_level=log_level, host=host, port=port, **kwargs))
-    @threaded(daemon=daemon)
+    @startthread(daemon=daemon)
     def run_server(): asyncio.run(server.serve())
-    run_server()
     while not server.started: time.sleep(0.01)
     return server
 

--- a/nbs/api/06_jupyter.ipynb
+++ b/nbs/api/06_jupyter.ipynb
@@ -225,7 +225,27 @@
    "execution_count": null,
    "id": "0f4b31e9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script>\n",
+       "document.body.addEventListener('htmx:configRequest', (event) => {\n",
+       "    if(event.detail.path.includes('://')) return;\n",
+       "    htmx.config.selfRequestsOnly=false;\n",
+       "    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;\n",
+       "});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "app = FastHTML()\n",
     "rt = app.route\n",
@@ -282,7 +302,27 @@
    "execution_count": null,
    "id": "97bfb966",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script>\n",
+       "document.body.addEventListener('htmx:configRequest', (event) => {\n",
+       "    if(event.detail.path.includes('://')) return;\n",
+       "    htmx.config.selfRequestsOnly=false;\n",
+       "    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;\n",
+       "});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "app = FastHTML()\n",
     "rt = app.route\n",
@@ -349,7 +389,27 @@
    "execution_count": null,
    "id": "959eb254",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script>\n",
+       "document.body.addEventListener('htmx:configRequest', (event) => {\n",
+       "    if(event.detail.path.includes('://')) return;\n",
+       "    htmx.config.selfRequestsOnly=false;\n",
+       "    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;\n",
+       "});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "server = JupyUviAsync(app, port=port)\n",
     "await server.start()"
@@ -431,12 +491,10 @@
       "text/html": [
        "<meta charset=\"utf-8\">\n",
        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\n",
-       "<script src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><script id=\"_sYwitiPjTPOxfXlN8cbv7w\">if (window.htmx) htmx.process(document.body)</script>"
+       "<script src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><script id=\"_AxFC49bqTX_vvHITdKX34w\">if (window.htmx) htmx.process(document.body)</script>"
       ],
       "text/plain": [
-       "HTML(<meta charset=\"utf-8\">\n",
-       "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\n",
-       "<script src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><script id=\"_sYwitiPjTPOxfXlN8cbv7w\">if (window.htmx) htmx.process(document.body)</script>)"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -461,7 +519,27 @@
    "execution_count": null,
    "id": "78d40711",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script>\n",
+       "document.body.addEventListener('htmx:configRequest', (event) => {\n",
+       "    if(event.detail.path.includes('://')) return;\n",
+       "    htmx.config.selfRequestsOnly=false;\n",
+       "    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;\n",
+       "});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "server = JupyUvi(app, port=port)"
    ]
@@ -474,19 +552,13 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div id=\"_A6gm38EFSH_ZhojZquM1uw\">\n",
-       "  <div id=\"_2sSCvGQjTeOeir_Hk3bjoQ\"></div>\n",
-       "<script id=\"_DboUW8T6TQSJJenetKuutw\">if (window.htmx) htmx.process(document.body)</script></div>\n"
-      ],
       "text/markdown": [
-       "```html\n",
-       "<div id=\"_2sSCvGQjTeOeir_Hk3bjoQ\"></div>\n",
-       "\n",
-       "```"
+       "<div id=\"_PxvQ15IuRXm9FIIqzd0s2g\">\n",
+       "  <div id=\"_BxxYJqh2RdOaxF3FIK0VBA\"></div>\n",
+       "<script id=\"_T5tPsHW3S4CHyiz8qnhcTA\">if (window.htmx) htmx.process(document.body)</script></div>\n"
       ],
       "text/plain": [
-       "<div id=\"_2sSCvGQjTeOeir_Hk3bjoQ\"></div>"
+       "div(('',),{'id': '_BxxYJqh2RdOaxF3FIK0VBA'})"
       ]
      },
      "execution_count": null,
@@ -525,19 +597,13 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div id=\"_oSI_9BPSR5qLAMHJVxJ60w\">\n",
-       "  <p hx-get=\"/hoho\" hx-trigger=\"load\" id=\"_qDKmfca0RlepEOFxc3ta2A\">not loaded</p>\n",
-       "<script id=\"_2_l4np5PQVu1Qz1tP-ao1Q\">if (window.htmx) htmx.process(document.body)</script></div>\n"
-      ],
       "text/markdown": [
-       "```html\n",
-       "<p hx-get=\"/hoho\" hx-trigger=\"load\" id=\"_qDKmfca0RlepEOFxc3ta2A\">not loaded</p>\n",
-       "\n",
-       "```"
+       "<div id=\"_XgMVy0kiSoqMdapiYOvKjQ\">\n",
+       "  <p hx-get=\"/hoho\" hx-trigger=\"load\" id=\"_x4TFzZPvTtWff74RmcHGVQ\">not loaded</p>\n",
+       "<script id=\"_bjgxEv1nSTSRImWdUhYk4Q\">if (window.htmx) htmx.process(document.body)</script></div>\n"
       ],
       "text/plain": [
-       "<p hx-get=\"/hoho\" hx-trigger=\"load\" id=\"_qDKmfca0RlepEOFxc3ta2A\">not loaded</p>"
+       "p(('not loaded',),{'hx-get': <fasthtml.core._mk_locfunc.<locals>._lf object>, 'hx-trigger': 'load', 'id': '_x4TFzZPvTtWff74RmcHGVQ'})"
       ]
      },
      "execution_count": null,
@@ -565,19 +631,13 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div id=\"_4WaqhrOOQfaAvelXMsO5pQ\">\n",
-       "  <div id=\"_PpxWR3UrT1umwwCOWfiXEg\"></div>\n",
-       "<script id=\"_cwIcpJ6ZRf2gbveffpIg4Q\">if (window.htmx) htmx.process(document.body)</script></div>\n"
-      ],
       "text/markdown": [
-       "```html\n",
-       "<div id=\"_PpxWR3UrT1umwwCOWfiXEg\"></div>\n",
-       "\n",
-       "```"
+       "<div id=\"_tLh3mf0ZRdecNW_hYz9eYA\">\n",
+       "  <div id=\"_AsIIqL_PTs_nPASliaNYGA\"></div>\n",
+       "<script id=\"_zVvvP66UT_aabITIdgho2g\">if (window.htmx) htmx.process(document.body)</script></div>\n"
       ],
       "text/plain": [
-       "<div id=\"_PpxWR3UrT1umwwCOWfiXEg\"></div>"
+       "div(('',),{'id': '_AsIIqL_PTs_nPASliaNYGA'})"
       ]
      },
      "execution_count": null,
@@ -597,19 +657,13 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div id=\"_r6_3NNhNRMG_wooINDhV_Q\">\n",
-       "  <p hx-get=\"/foo\" hx-trigger=\"load\" hx-target=\"#_PpxWR3UrT1umwwCOWfiXEg\" id=\"_yZ51FvYZTb_1sODJFRr47A\">hi</p>\n",
-       "<script id=\"_d-TBRtWuSniQ0sTmQ6hfZg\">if (window.htmx) htmx.process(document.body)</script></div>\n"
-      ],
       "text/markdown": [
-       "```html\n",
-       "<p hx-get=\"/foo\" hx-trigger=\"load\" hx-target=\"#_PpxWR3UrT1umwwCOWfiXEg\" id=\"_yZ51FvYZTb_1sODJFRr47A\">hi</p>\n",
-       "\n",
-       "```"
+       "<div id=\"_ofCzAKDvSsWqGb_i-9X95A\">\n",
+       "  <p hx-get=\"/foo\" hx-trigger=\"load\" hx-target=\"#_AsIIqL_PTs_nPASliaNYGA\" id=\"_LjH2GVPJS_6wMMIQSQpyJA\">hi</p>\n",
+       "<script id=\"_tWo0Xu7TSQGyuYfd68xuaA\">if (window.htmx) htmx.process(document.body)</script></div>\n"
       ],
       "text/plain": [
-       "<p hx-get=\"/foo\" hx-trigger=\"load\" hx-target=\"#_PpxWR3UrT1umwwCOWfiXEg\" id=\"_yZ51FvYZTb_1sODJFRr47A\">hi</p>"
+       "p(('hi',),{'hx-get': <fasthtml.core._mk_locfunc.<locals>._lf object>, 'hx-trigger': 'load', 'hx-target': '#_AsIIqL_PTs_nPASliaNYGA', 'id': '_LjH2GVPJS_6wMMIQSQpyJA'})"
       ]
      },
      "execution_count": null,
@@ -742,13 +796,7 @@
        "    }\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> "
       ],
       "text/plain": [
-       "HTML(<iframe src=\"http://localhost:8000/\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
-       "        let frame = this;\n",
-       "        window.addEventListener('message', function(e) {\n",
-       "            if (e.source !== frame.contentWindow) return; // Only proceed if the message is from this iframe\n",
-       "            if (e.data.height) frame.style.height = (e.data.height+1) + 'px';\n",
-       "        }, false);\n",
-       "    }\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> )"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "execution_count": null,
@@ -811,16 +859,21 @@
     "#| hide\n",
     "import nbdev; nbdev.nbdev_export()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6eafdc3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
-  "solveit": {
-   "default_code": true,
-   "mode": "learning",
-   "use_fence": false,
-   "use_thinking": true,
-   "use_tools": true,
-   "ver": 2
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/nbs/api/06_jupyter.ipynb
+++ b/nbs/api/06_jupyter.ipynb
@@ -35,7 +35,7 @@
     "from fastcore.meta import delegates\n",
     "from fasthtml.common import *\n",
     "from fasthtml.common import show as _show\n",
-    "from fastcore.parallel import startthread\n",
+    "from fastcore.parallel import threaded\n",
     "try: from IPython.display import HTML,Markdown,display\n",
     "except ImportError: pass"
    ]
@@ -69,8 +69,9 @@
     "def nb_serve(app, log_level=\"error\", port=8000, host='0.0.0.0', daemon=False, **kwargs):\n",
     "    \"Start a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`; use `daemon=True` for notebook tests so failed runs don't block process shutdown\"\n",
     "    server = uvicorn.Server(uvicorn.Config(app, log_level=log_level, host=host, port=port, **kwargs))\n",
-    "    server.thread = Thread(target=lambda: asyncio.run(server.serve()), daemon=daemon)\n",
-    "    server.thread.start()\n",
+    "    @threaded(daemon=daemon)\n",
+    "    def run_server(): asyncio.run(server.serve())\n",
+    "    run_server()\n",
     "    while not server.started: time.sleep(0.01)\n",
     "    return server"
    ]
@@ -194,7 +195,7 @@
     "#| export\n",
     "class JupyUvi:\n",
     "    \"Start and stop a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`\"\n",
-    "    def __init__(self, app, log_level=\"error\", host='0.0.0.0', port=8000, start=True, **kwargs):\n",
+    "    def __init__(self, app, log_level=\"error\", host='0.0.0.0', port=8000, start=True, daemon=False, **kwargs):\n",
     "        self.kwargs = kwargs\n",
     "        store_attr(but='start')\n",
     "        self.server = None\n",
@@ -202,14 +203,13 @@
     "        if not os.environ.get('IN_SOLVEIT'): htmx_config_port(port)\n",
     "\n",
     "    def start(self):\n",
-    "        self.server = nb_serve(self.app, log_level=self.log_level, host=self.host, port=self.port, **self.kwargs)\n",
+    "        self.server = nb_serve(self.app, log_level=self.log_level, host=self.host, port=self.port,daemon=self.daemon, **self.kwargs)\n",
     "\n",
     "    async def start_async(self):\n",
     "        self.server = await nb_serve_async(self.app, log_level=self.log_level, host=self.host, port=self.port, **self.kwargs)\n",
     "\n",
     "    def stop(self):\n",
     "        self.server.should_exit = True\n",
-    "        if hasattr(self.server, 'thread'): self.server.thread.join(timeout=3)\n",
     "        wait_port_free(self.port)\n"
    ]
   },
@@ -860,14 +860,6 @@
     "#| hide\n",
     "import nbdev; nbdev.nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6eafdc3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/nbs/api/06_jupyter.ipynb
+++ b/nbs/api/06_jupyter.ipynb
@@ -35,7 +35,7 @@
     "from fastcore.meta import delegates\n",
     "from fasthtml.common import *\n",
     "from fasthtml.common import show as _show\n",
-    "from fastcore.parallel import threaded\n",
+    "from fastcore.parallel import startthread\n",
     "try: from IPython.display import HTML,Markdown,display\n",
     "except ImportError: pass"
    ]
@@ -69,9 +69,8 @@
     "def nb_serve(app, log_level=\"error\", port=8000, host='0.0.0.0', daemon=False, **kwargs):\n",
     "    \"Start a Jupyter compatible uvicorn server with ASGI `app` on `port` with `log_level`; use `daemon=True` for notebook tests so failed runs don't block process shutdown\"\n",
     "    server = uvicorn.Server(uvicorn.Config(app, log_level=log_level, host=host, port=port, **kwargs))\n",
-    "    @threaded(daemon=daemon)\n",
+    "    @startthread(daemon=daemon)\n",
     "    def run_server(): asyncio.run(server.serve())\n",
-    "    run_server()\n",
     "    while not server.started: time.sleep(0.01)\n",
     "    return server"
    ]
@@ -226,27 +225,7 @@
    "execution_count": null,
    "id": "0f4b31e9",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script>\n",
-       "document.body.addEventListener('htmx:configRequest', (event) => {\n",
-       "    if(event.detail.path.includes('://')) return;\n",
-       "    htmx.config.selfRequestsOnly=false;\n",
-       "    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;\n",
-       "});\n",
-       "</script>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "app = FastHTML()\n",
     "rt = app.route\n",
@@ -303,27 +282,7 @@
    "execution_count": null,
    "id": "97bfb966",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script>\n",
-       "document.body.addEventListener('htmx:configRequest', (event) => {\n",
-       "    if(event.detail.path.includes('://')) return;\n",
-       "    htmx.config.selfRequestsOnly=false;\n",
-       "    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;\n",
-       "});\n",
-       "</script>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "app = FastHTML()\n",
     "rt = app.route\n",
@@ -390,27 +349,7 @@
    "execution_count": null,
    "id": "959eb254",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script>\n",
-       "document.body.addEventListener('htmx:configRequest', (event) => {\n",
-       "    if(event.detail.path.includes('://')) return;\n",
-       "    htmx.config.selfRequestsOnly=false;\n",
-       "    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;\n",
-       "});\n",
-       "</script>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "server = JupyUviAsync(app, port=port)\n",
     "await server.start()"
@@ -492,10 +431,12 @@
       "text/html": [
        "<meta charset=\"utf-8\">\n",
        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\n",
-       "<script src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><script id=\"_AxFC49bqTX_vvHITdKX34w\">if (window.htmx) htmx.process(document.body)</script>"
+       "<script src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><script id=\"_sYwitiPjTPOxfXlN8cbv7w\">if (window.htmx) htmx.process(document.body)</script>"
       ],
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "HTML(<meta charset=\"utf-8\">\n",
+       "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\n",
+       "<script src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\"></script><script src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\"></script><script id=\"_sYwitiPjTPOxfXlN8cbv7w\">if (window.htmx) htmx.process(document.body)</script>)"
       ]
      },
      "metadata": {},
@@ -520,27 +461,7 @@
    "execution_count": null,
    "id": "78d40711",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script>\n",
-       "document.body.addEventListener('htmx:configRequest', (event) => {\n",
-       "    if(event.detail.path.includes('://')) return;\n",
-       "    htmx.config.selfRequestsOnly=false;\n",
-       "    event.detail.path = `${location.protocol}//${location.hostname}:8000${event.detail.path}`;\n",
-       "});\n",
-       "</script>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "server = JupyUvi(app, port=port)"
    ]
@@ -553,13 +474,19 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div id=\"_A6gm38EFSH_ZhojZquM1uw\">\n",
+       "  <div id=\"_2sSCvGQjTeOeir_Hk3bjoQ\"></div>\n",
+       "<script id=\"_DboUW8T6TQSJJenetKuutw\">if (window.htmx) htmx.process(document.body)</script></div>\n"
+      ],
       "text/markdown": [
-       "<div id=\"_PxvQ15IuRXm9FIIqzd0s2g\">\n",
-       "  <div id=\"_BxxYJqh2RdOaxF3FIK0VBA\"></div>\n",
-       "<script id=\"_T5tPsHW3S4CHyiz8qnhcTA\">if (window.htmx) htmx.process(document.body)</script></div>\n"
+       "```html\n",
+       "<div id=\"_2sSCvGQjTeOeir_Hk3bjoQ\"></div>\n",
+       "\n",
+       "```"
       ],
       "text/plain": [
-       "div(('',),{'id': '_BxxYJqh2RdOaxF3FIK0VBA'})"
+       "<div id=\"_2sSCvGQjTeOeir_Hk3bjoQ\"></div>"
       ]
      },
      "execution_count": null,
@@ -598,13 +525,19 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div id=\"_oSI_9BPSR5qLAMHJVxJ60w\">\n",
+       "  <p hx-get=\"/hoho\" hx-trigger=\"load\" id=\"_qDKmfca0RlepEOFxc3ta2A\">not loaded</p>\n",
+       "<script id=\"_2_l4np5PQVu1Qz1tP-ao1Q\">if (window.htmx) htmx.process(document.body)</script></div>\n"
+      ],
       "text/markdown": [
-       "<div id=\"_XgMVy0kiSoqMdapiYOvKjQ\">\n",
-       "  <p hx-get=\"/hoho\" hx-trigger=\"load\" id=\"_x4TFzZPvTtWff74RmcHGVQ\">not loaded</p>\n",
-       "<script id=\"_bjgxEv1nSTSRImWdUhYk4Q\">if (window.htmx) htmx.process(document.body)</script></div>\n"
+       "```html\n",
+       "<p hx-get=\"/hoho\" hx-trigger=\"load\" id=\"_qDKmfca0RlepEOFxc3ta2A\">not loaded</p>\n",
+       "\n",
+       "```"
       ],
       "text/plain": [
-       "p(('not loaded',),{'hx-get': <fasthtml.core._mk_locfunc.<locals>._lf object>, 'hx-trigger': 'load', 'id': '_x4TFzZPvTtWff74RmcHGVQ'})"
+       "<p hx-get=\"/hoho\" hx-trigger=\"load\" id=\"_qDKmfca0RlepEOFxc3ta2A\">not loaded</p>"
       ]
      },
      "execution_count": null,
@@ -632,13 +565,19 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div id=\"_4WaqhrOOQfaAvelXMsO5pQ\">\n",
+       "  <div id=\"_PpxWR3UrT1umwwCOWfiXEg\"></div>\n",
+       "<script id=\"_cwIcpJ6ZRf2gbveffpIg4Q\">if (window.htmx) htmx.process(document.body)</script></div>\n"
+      ],
       "text/markdown": [
-       "<div id=\"_tLh3mf0ZRdecNW_hYz9eYA\">\n",
-       "  <div id=\"_AsIIqL_PTs_nPASliaNYGA\"></div>\n",
-       "<script id=\"_zVvvP66UT_aabITIdgho2g\">if (window.htmx) htmx.process(document.body)</script></div>\n"
+       "```html\n",
+       "<div id=\"_PpxWR3UrT1umwwCOWfiXEg\"></div>\n",
+       "\n",
+       "```"
       ],
       "text/plain": [
-       "div(('',),{'id': '_AsIIqL_PTs_nPASliaNYGA'})"
+       "<div id=\"_PpxWR3UrT1umwwCOWfiXEg\"></div>"
       ]
      },
      "execution_count": null,
@@ -658,13 +597,19 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div id=\"_r6_3NNhNRMG_wooINDhV_Q\">\n",
+       "  <p hx-get=\"/foo\" hx-trigger=\"load\" hx-target=\"#_PpxWR3UrT1umwwCOWfiXEg\" id=\"_yZ51FvYZTb_1sODJFRr47A\">hi</p>\n",
+       "<script id=\"_d-TBRtWuSniQ0sTmQ6hfZg\">if (window.htmx) htmx.process(document.body)</script></div>\n"
+      ],
       "text/markdown": [
-       "<div id=\"_ofCzAKDvSsWqGb_i-9X95A\">\n",
-       "  <p hx-get=\"/foo\" hx-trigger=\"load\" hx-target=\"#_AsIIqL_PTs_nPASliaNYGA\" id=\"_LjH2GVPJS_6wMMIQSQpyJA\">hi</p>\n",
-       "<script id=\"_tWo0Xu7TSQGyuYfd68xuaA\">if (window.htmx) htmx.process(document.body)</script></div>\n"
+       "```html\n",
+       "<p hx-get=\"/foo\" hx-trigger=\"load\" hx-target=\"#_PpxWR3UrT1umwwCOWfiXEg\" id=\"_yZ51FvYZTb_1sODJFRr47A\">hi</p>\n",
+       "\n",
+       "```"
       ],
       "text/plain": [
-       "p(('hi',),{'hx-get': <fasthtml.core._mk_locfunc.<locals>._lf object>, 'hx-trigger': 'load', 'hx-target': '#_AsIIqL_PTs_nPASliaNYGA', 'id': '_LjH2GVPJS_6wMMIQSQpyJA'})"
+       "<p hx-get=\"/foo\" hx-trigger=\"load\" hx-target=\"#_PpxWR3UrT1umwwCOWfiXEg\" id=\"_yZ51FvYZTb_1sODJFRr47A\">hi</p>"
       ]
      },
      "execution_count": null,
@@ -797,7 +742,13 @@
        "    }\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> "
       ],
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "HTML(<iframe src=\"http://localhost:8000/\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
+       "        let frame = this;\n",
+       "        window.addEventListener('message', function(e) {\n",
+       "            if (e.source !== frame.contentWindow) return; // Only proceed if the message is from this iframe\n",
+       "            if (e.data.height) frame.style.height = (e.data.height+1) + 'px';\n",
+       "        }, false);\n",
+       "    }\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> )"
       ]
      },
      "execution_count": null,
@@ -863,10 +814,13 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "python3",
-   "language": "python",
-   "name": "python3"
+  "solveit": {
+   "default_code": true,
+   "mode": "learning",
+   "use_fence": false,
+   "use_thinking": true,
+   "use_tools": true,
+   "ver": 2
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard and contributors", email = "github@jhoward.fastmail.fm"}]
 keywords = ['nbdev', 'jupyter', 'notebook', 'python']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 3 - Alpha", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['fastcore>=1.12.41', 'python-dateutil', 'starlette~=1.0', 'oauthlib', 'itsdangerous', 'uvicorn[standard]>=0.30', 'httpx', 'fastlite>=0.1.1', 'python-multipart', 'beautifulsoup4']
+dependencies = ['fastcore>=1.12.44', 'python-dateutil', 'starlette~=1.0', 'oauthlib', 'itsdangerous', 'uvicorn[standard]>=0.30', 'httpx', 'fastlite>=0.1.1', 'python-multipart', 'beautifulsoup4']
 
 [project.urls]
 Repository = "https://github.com/AnswerDotAI/fasthtml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard and contributors", email = "github@jhoward.fastmail.fm"}]
 keywords = ['nbdev', 'jupyter', 'notebook', 'python']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 3 - Alpha", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['fastcore>=1.12.44', 'python-dateutil', 'starlette~=1.0', 'oauthlib', 'itsdangerous', 'uvicorn[standard]>=0.30', 'httpx', 'fastlite>=0.1.1', 'python-multipart', 'beautifulsoup4']
+dependencies = ['fastcore>=1.12.45', 'python-dateutil', 'starlette~=1.0', 'oauthlib', 'itsdangerous', 'uvicorn[standard]>=0.30', 'httpx', 'fastlite>=0.1.1', 'python-multipart', 'beautifulsoup4']
 
 [project.urls]
 Repository = "https://github.com/AnswerDotAI/fasthtml"


### PR DESCRIPTION
Moved `JupyUvi` to use `threaded`.

Decisions taken:

Decided to remove any thread reference. Using`daemon=True` fixes the original problem: if `.stop()` is never called, the leftover uvicorn thread won’t block process shutdown. 

Calling`join()` only helps when `.stop()` is called, by waiting for the server thread to actually finish. But we already call `wait_port_free()` so this extra `join(...)` is useful but not essential, and given that it requires extra thread code I decided to just remove it.

