### PR TITLE
Fix import error uvicorn.run in serve()

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -810,7 +810,7 @@ def serve(
         if not port: port=int(os.getenv("PORT", default=5001))
         link = f'http://{"localhost" if host=="0.0.0.0" else host}:{port}'
         print('Link: '+ S.light_red.bold(link))
-        uvicorn.run(f'{appname}:{app}', host=host, port=port, reload=reload, **kwargs)
+        run(f'{appname}:{app}', host=host, port=port, reload=reload, **kwargs)
 
 # %% ../nbs/api/00_core.ipynb #8121968a
 class Client:

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -2283,7 +2283,7 @@
     "        if not port: port=int(os.getenv(\"PORT\", default=5001))\n",
     "        link = f'http://{\"localhost\" if host==\"0.0.0.0\" else host}:{port}'\n",
     "        print('Link: '+ S.light_red.bold(link))\n",
-    "        uvicorn.run(f'{appname}:{app}', host=host, port=port, reload=reload, **kwargs)"
+    "        run(f'{appname}:{app}', host=host, port=port, reload=reload, **kwargs)"
    ]
   },
   {
@@ -4699,6 +4699,9 @@
   }
  ],
  "metadata": {
+  "language_info": {
+   "name": "python"
+  },
   "solveit": {
    "default_code": false,
    "mode": "learning",


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] '
labels: ''
assignees: ''

---

**Related Issue**
https://github.com/AnswerDotAI/fasthtml/issues/877
In `core.py`, we have `from uvicorn import run`, but run with `uvicorn.run`

**Proposed Changes**
Replace `uvicorn.run` with just `run` in `serve()`

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.