### PR TITLE
Fix broken docs link for custom ft components

### DIFF
--- a/nbs/explains/explaining_xt_components.ipynb
+++ b/nbs/explains/explaining_xt_components.ipynb
@@ -297,7 +297,7 @@
     "\n",
     "It is possible and sometimes useful to create your own ft components that generate non-standard tags that are not in the FastHTML library.  FastHTML supports created and defining those new tags flexibly.\n",
     "\n",
-    "For more information, see the [Defining new ft components](/ref/defining_xt_component.html) reference page."
+    "For more information, see the [Defining new ft components](/docs/ref/defining_xt_component.html) reference page."
    ]
   },
   {


### PR DESCRIPTION
Fixes #676.

Updates the notebook docs link for “Defining new ft components” from `/ref/defining_xt_component.html` to `/docs/ref/defining_xt_component.html`.

I verified the old URL returns 404 and the new URL returns 200.