### PR TITLE
fix: explicit GET method for auto static routes to stop shadowing dyn…

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -916,14 +916,14 @@ reg_re_param("static", '|'.join(_static_exts))
 @patch
 def static_route_exts(self:FastHTML, prefix='/', static_path='.', exts='static'):
     "Add a static route at URL path `prefix` with files from `static_path` and `exts` defined by `reg_re_param()`"
-    @self.route(f"{prefix}{{fname:path}}.{{ext:{exts}}}")
+    @self.get(f"{prefix}{{fname:path}}.{{ext:{exts}}}")
     async def get(fname:str, ext:str): return FileResponse(f'{static_path}/{fname}.{ext}')
 
 # %% ../nbs/api/00_core.ipynb #b31de65a
 @patch
 def static_route(self:FastHTML, ext='', prefix='/', static_path='.'):
     "Add a static route at URL path `prefix` with files from `static_path` and single `ext` (including the '.')"
-    @self.route(f"{prefix}{{fname:path}}{ext}")
+    @self.get(f"{prefix}{{fname:path}}{ext}")
     async def get(fname:str): return FileResponse(f'{static_path}/{fname}{ext}')
 
 # %% ../nbs/api/00_core.ipynb #f63b7a03

--- a/tests/test_static_shadowing.py
+++ b/tests/test_static_shadowing.py
@@ -1,0 +1,15 @@
+from fasthtml.common import fast_app
+from starlette.testclient import TestClient
+
+def test_fast_app_static_ext_route_does_not_shadow_post():
+    app, rt = fast_app()
+
+    @rt("/x/{a}/{path:path}", methods=["GET", "POST", "PUT"])
+    async def catchall(a: str, path: str, request):
+        return {"matched": True, "a": a, "path": path, "method": request.method}
+
+    client = TestClient(app)
+
+    # Assert that POST requests ending in static extensions hit the dynamic endpoint instead of throwing a 404
+    assert client.post("/x/SID/file.xls").status_code == 200
+    assert client.post("/x/SID/sub/file.xlsx").status_code == 200


### PR DESCRIPTION
name: Pull Request
about: Propose changes to the codebase
title: '[PR] fix: explicit GET method for auto static routes to stop shadowing dynamic POST endpoints'
labels: 'bug'
assignees: ''

Related Issue
Fixes #888

Proposed Changes
The auto static-extension routes (static_route_exts and static_route) were automatically registering for POST as well as GET. This caused them to intercept and 404 any POST requests that ended in file extensions (like .xls), completely shadowing dynamic catch-all routes.

I explicitly changed @self.route to @self.get for these static handlers so they strictly handle GET/HEAD requests and leave POSTs alone.

I also added a test case in tests/test_static_shadowing.py to verify that POSTs to URLs with extensions now hit the dynamic route correctly.

Note: When running the test suite, test_toaster.py::test_get_toaster_with_typehint failed on my end, but it looks like an unrelated existing issue.

Types of changes

[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to change)

Checklist

[x] My code follows the code style of this project.

[ ] My change requires a change to the documentation.

[ ] I have updated the documentation accordingly.

[x] I have added tests to cover my changes.

[x] All new and existing tests passed.

[x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.