### PR TITLE
fix(core): rename parameter f to _f in _handle to prevent keyword argument collisions

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -276,8 +276,8 @@ class Beforeware:
     def __repr__(self): return f'Beforeware({self.f}, skip={self.skip})'
 
 # %% ../nbs/api/00_core.ipynb #78c3c357
-async def _handle(f, *args, **kwargs):
-    return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)
+async def _handle(_f, *args, **kwargs):
+    return (await _f(*args, **kwargs)) if is_async_callable(_f) else await run_in_threadpool(_f, *args, **kwargs)
 
 # %% ../nbs/api/00_core.ipynb #ad0f0e87
 async def _wrap_ws(ws, data, params):

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1132,8 +1132,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "async def _handle(f, *args, **kwargs):\n",
-    "    return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)"
+    "async def _handle(_f, *args, **kwargs):\n",
+    "    return (await _f(*args, **kwargs)) if is_async_callable(_f) else await run_in_threadpool(_f, *args, **kwargs)"
    ]
   },
   {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,16 @@
+from fasthtml.common import *
+from starlette.testclient import TestClient
+
+app, rt = fast_app()
+cli = TestClient(app)
+
+@rt("/test-f")
+def post(f: str):
+    return Titled("Success", P(f"Value: {f}"))
+
+def test_argument_f_collision():
+    res = cli.post('/test-f', data={'f': 'hello'})
+    assert res.status_code == 200
+    assert 'Value: hello' in res.text
+
+test_argument_f_collision()


### PR DESCRIPTION
When route handlers accept an argument named `f` (representing a file, form, or general parameter), invoking the handler via FastHTML's `_handle` function raises `TypeError: _handle() got multiple values for argument 'f'`.

This is because the first positional argument of `_handle` is named `f`, which collides with the keyword argument unpacked from the request payload.

This PR renames the parameter in `_handle` from `f` to `_f` (both in the source notebook `nbs/api/00_core.ipynb` and the exported `fasthtml/core.py`) to prevent keyword collisions.

I've also added a regression test demonstrating route registration and invocation with parameter `f` working seamlessly.

Closes #834