### PR TITLE
Make _handle param f positional-only to avoid form field collision

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -276,7 +276,7 @@ class Beforeware:
     def __repr__(self): return f'Beforeware({self.f}, skip={self.skip})'
 
 # %% ../nbs/api/00_core.ipynb #78c3c357
-async def _handle(f, *args, **kwargs):
+async def _handle(f, /, *args, **kwargs):
     return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)
 
 # %% ../nbs/api/00_core.ipynb #ad0f0e87

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -132,7 +132,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2026, 6, 27, 14, 0)"
+       "datetime.datetime(2026, 6, 29, 14, 0)"
       ]
      },
      "execution_count": null,
@@ -1132,8 +1132,19 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "async def _handle(f, *args, **kwargs):\n",
+    "async def _handle(f, /, *args, **kwargs):\n",
     "    return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c995850c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _f(f): return f\"got {f}\"\n",
+    "test_eq(await _handle(_f, f='hello'), 'got hello')"
    ]
   },
   {
@@ -3371,13 +3382,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Set to 2026-06-27 12:38:48.010675\n"
+      "Set to 2026-06-29 21:09:52.332526\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'Session time: 2026-06-27 12:38:48.010675'"
+       "'Session time: 2026-06-29 21:09:52.332526'"
       ]
      },
      "execution_count": null,
@@ -4127,7 +4138,7 @@
     {
      "data": {
       "text/plain": [
-       "'Cookie was set at time 12:38:49.482843'"
+       "'Cookie was set at time 21:09:55.336114'"
       ]
      },
      "execution_count": null,


### PR DESCRIPTION
Closes #834

- `f` as a parameter triggers `TypeError: _handle() got multiple values for argument 'f'`, because the form field `f` arrives via `**wreq` and collides with `_handle`'s positional `f` (the handler itself).

- Makes `f` positional-only with `/`: `async def _handle(f, /, *args, **kwargs)`. This is the standard stdlib idiom (`functools.partial`, `functools.reduce`) and is preferable to renaming (e.g. `_f`), which only relocates the collision to a different field name.

- notebook fasthtml/nbs/api/00_core.py was edited, synced (not `core.py` directly), cleaned. Test is in `nbs/api/00_core.ipynb` right under _handle.