### PR TITLE
Add fast __deepcopy__ for FT to avoid slow generic object fallback

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -40,6 +40,19 @@ from email.utils import format_datetime
 
 from .starlette import *
 
+# %% ../nbs/api/00_core.ipynb #2b18bf01
+@patch
+def __deepcopy__(self:FT, memo):
+    "Fast `deepcopy` for `FT`, avoiding the slow generic object fallback. Unknown attr/child value types are delegated to `deepcopy` itself, so a user's own `__deepcopy__` is still respected"
+    y = self.__class__.__new__(self.__class__)
+    memo[id(self)] = y
+    y.tag = self.tag
+    y.children = tuple(deepcopy(c, memo) for c in self.children)
+    y.attrs = deepcopy(self.attrs, memo)
+    y.void_ = self.void_
+    y.listeners_ = deepcopy(self.listeners_, memo)
+    return y
+
 # %% ../nbs/api/00_core.ipynb #19d3f2a7
 def _params(f): return signature_ex(f, True).parameters
 

--- a/fasthtml/core.pyi
+++ b/fasthtml/core.pyi
@@ -22,6 +22,11 @@ from base64 import b64encode, b64decode
 from email.utils import format_datetime
 from .starlette import *
 
+@patch
+def __deepcopy__(self: FT, memo):
+    """Fast `deepcopy` for `FT`, avoiding the slow generic object fallback. Unknown attr/child value types are delegated to `deepcopy` itself, so a user's own `__deepcopy__` is still respected"""
+    ...
+
 def _params(f):
     ...
 empty = Parameter.empty

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -93,6 +93,106 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2b18bf01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| export\n",
+    "@patch\n",
+    "def __deepcopy__(self:FT, memo):\n",
+    "    \"Fast `deepcopy` for `FT`, avoiding the slow generic object fallback. Unknown attr/child value types are delegated to `deepcopy` itself, so a user's own `__deepcopy__` is still respected\"\n",
+    "    y = self.__class__.__new__(self.__class__)\n",
+    "    memo[id(self)] = y\n",
+    "    y.tag = self.tag\n",
+    "    y.children = tuple(deepcopy(c, memo) for c in self.children)\n",
+    "    y.attrs = deepcopy(self.attrs, memo)\n",
+    "    y.void_ = self.void_\n",
+    "    y.listeners_ = deepcopy(self.listeners_, memo)\n",
+    "    return y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9ecba07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "el = Div(Span('hi', cls='a'), id='x')\n",
+    "cp = deepcopy(el)\n",
+    "test_eq(cp, el)\n",
+    "test_ne(id(cp), id(el))\n",
+    "test_ne(id(cp.attrs), id(el.attrs))\n",
+    "test_ne(id(cp.children[0]), id(el.children[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b69aa77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nested = Div(Div(Span('hi', cls='a')))\n",
+    "cp = deepcopy(nested)\n",
+    "cp.children[0].children[0].attrs['class'] = 'mutated'\n",
+    "test_eq(nested.children[0].children[0].attrs['class'], 'a')\n",
+    "test_eq(cp.children[0].children[0].attrs['class'], 'mutated')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50296a48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v = Meta(charset='utf-8')\n",
+    "cp = deepcopy(v)\n",
+    "test_eq(cp.void_, True)\n",
+    "test_eq(cp, v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69795726",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Custom:\n",
+    "    def __init__(self, v): self.v = v\n",
+    "    def __deepcopy__(self, memo):\n",
+    "        c = Custom(self.v)\n",
+    "        memo[id(self)] = c\n",
+    "        return c\n",
+    "    def __eq__(self, o): return isinstance(o, Custom) and o.v == self.v\n",
+    "\n",
+    "el = Div(x=Custom(5))\n",
+    "cp = deepcopy(el)\n",
+    "test_eq(type(cp.attrs['x']), Custom)\n",
+    "test_ne(id(cp.attrs['x']), id(el.attrs['x']))\n",
+    "test_eq(cp.attrs['x'].v, 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fce2d92a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app, rt = fast_app()\n",
+    "hdrs, ftrs, htmlkw, bodykw = app.hdrs, app.ftrs, app.htmlkw, app.bodykw\n",
+    "r = deepcopy((hdrs, ftrs, htmlkw, bodykw))\n",
+    "test_eq(r, (hdrs, ftrs, htmlkw, bodykw))\n",
+    "test_ne(id(r[0][0]), id(hdrs[0]))\n",
+    "test_ne(id(r[0][0].attrs), id(hdrs[0].attrs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "19d3f2a7",
    "metadata": {},
    "outputs": [],
@@ -4989,6 +5089,9 @@
   }
  ],
  "metadata": {
+  "language_info": {
+   "name": "python"
+  },
   "solveit": {
    "default_code": false,
    "mode": "concise",


### PR DESCRIPTION
---
**Related Issue**
N/A (performance optimization)

**Proposed Changes**
Add a fast [__deepcopy__](cci:1://file:///home/amirali/work/mine/fasthtml/fasthtml/core.pyi:24:0-27:7) implementation for `FT` (Fast Tag) to avoid the slow generic object fallback. The implementation directly copies the five core fields (`tag`, `children`, `attrs`, `void_`, `listeners_`) while delegating unknown attr/child value types to `deepcopy` itself, so user-defined [__deepcopy__](cci:1://file:///home/amirali/work/mine/fasthtml/fasthtml/core.pyi:24:0-27:7) methods are still respected. This improves performance when copying FT components.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Tests added in `nbs/api/00_core.ipynb` cover:
- Basic deepcopy with identity verification
- Nested structure mutation isolation
- Void element preservation
- Custom [__deepcopy__](cci:1://file:///home/amirali/work/mine/fasthtml/fasthtml/core.pyi:24:0-27:7) delegation
- `fast_app()` header/footer deepcopy
---