### PR TITLE
Replace Pico CSS with the anyblades pico fork

### DIFF
--- a/fasthtml/pico.py
+++ b/fasthtml/pico.py
@@ -21,24 +21,23 @@ try: from IPython import display
 except ImportError: display=None
 
 # %% ../nbs/api/04_pico.ipynb #100414ae
-picocss = "https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css"
+picocss = "https://cdn.jsdelivr.net/npm/@anyblades/pico@latest/css/pico.min.css"
 picolink = (Link(rel="stylesheet", href=picocss),
             Style(":root { --pico-font-size: 100%; }"))
-picocondcss = "https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.conditional.min.css"
+picocondcss = "https://cdn.jsdelivr.net/npm/@anyblades/pico@latest/css/pico.conditional.min.css"
 picocondlink = (Link(rel="stylesheet", href=picocondcss),
                 Style(":root { --pico-font-size: 100%; }"))
 
 # %% ../nbs/api/04_pico.ipynb #36d26fb7
 def set_pico_cls():
-    js = """var sel = '.cell-output, .output_area';
+    js = """var sel = '.cell-output, .output_area, .card-out .msg-content';
 document.querySelectorAll(sel).forEach(e => e.classList.add('pico'));
 
 new MutationObserver(ms => {
   ms.forEach(m => {
     m.addedNodes.forEach(n => {
       if (n.nodeType === 1) {
-        var nc = n.classList;
-        if (nc && (nc.contains('cell-output') || nc.contains('output_area'))) nc.add('pico');
+        if (n.matches(sel)) n.classList.add('pico');
         n.querySelectorAll(sel).forEach(e => e.classList.add('pico'));
       }
     });

--- a/nbs/api/04_pico.ipynb
+++ b/nbs/api/04_pico.ipynb
@@ -47,10 +47,10 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "picocss = \"https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.min.css\"\n",
+    "picocss = \"https://cdn.jsdelivr.net/npm/@anyblades/pico@latest/css/pico.min.css\"\n",
     "picolink = (Link(rel=\"stylesheet\", href=picocss),\n",
     "            Style(\":root { --pico-font-size: 100%; }\"))\n",
-    "picocondcss = \"https://cdn.jsdelivr.net/npm/@picocss/pico@latest/css/pico.conditional.min.css\"\n",
+    "picocondcss = \"https://cdn.jsdelivr.net/npm/@anyblades/pico@latest/css/pico.conditional.min.css\"\n",
     "picocondlink = (Link(rel=\"stylesheet\", href=picocondcss),\n",
     "                Style(\":root { --pico-font-size: 100%; }\"))"
    ]
@@ -97,15 +97,14 @@
    "source": [
     "#| export\n",
     "def set_pico_cls():\n",
-    "    js = \"\"\"var sel = '.cell-output, .output_area';\n",
+    "    js = \"\"\"var sel = '.cell-output, .output_area, .card-out .msg-content';\n",
     "document.querySelectorAll(sel).forEach(e => e.classList.add('pico'));\n",
     "\n",
     "new MutationObserver(ms => {\n",
     "  ms.forEach(m => {\n",
     "    m.addedNodes.forEach(n => {\n",
     "      if (n.nodeType === 1) {\n",
-    "        var nc = n.classList;\n",
-    "        if (nc && (nc.contains('cell-output') || nc.contains('output_area'))) nc.add('pico');\n",
+    "        if (n.matches(sel)) n.classList.add('pico');\n",
     "        n.querySelectorAll(sel).forEach(e => e.classList.add('pico'));\n",
     "      }\n",
     "    });\n",


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: '[PR] Replace Pico CSS CDN assets with anyblades CSS fork'
labels: ''
assignees: ''

---

**Related Issue**
https://github.com/AnswerDotAI/fasthtml/issues/883

**Proposed Changes**
- Replace the Pico CSS with the actively maintained CSS fork.
- Fix conditional Pico CSS breaking Solveit layouts
- `set_pico_cls()` can support Solveit as well as Jupyter. For Solveit, it can add the `pico` class to `.msg-content` elements inside `.card-out`

However, automatically placing every Solveit output under the pico scope changes the appearance of normal outputs that are not intended to be Pico UI.

Default SolveIt:
<img width="237" height="151" alt="image" src="https://github.com/user-attachments/assets/45a2ec84-b366-4976-aa53-e1b88f80d728" />
With picocond:
<img width="356" height="234" alt="image" src="https://github.com/user-attachments/assets/564c68be-19be-460b-9642-86ec935b607a" />

Not blocking, but I’m not sure whether there is a better way to handle this. @jph00 

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I am aware that this is an nbdev project, and I have edited, cleaned, and synced the source notebooks instead of editing .py or .md files directly.

**Additional Information**
Any additional information, configuration or data that might be necessary to reproduce the issue.
