### PR TITLE
Fix: add_sig_param: pass annotation to Parameter

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -1025,7 +1025,7 @@ def add_sig_param(f, name, typ=NoneType, kind=Parameter.KEYWORD_ONLY, default=Pa
     sig = signature(f)
     if name in sig.parameters: return f
     kw = {} if default is Parameter.empty else {'default': default}
-    new_params = list(sig.parameters.values()) + [Parameter(name, kind, **kw)]
+    new_params = list(sig.parameters.values()) + [Parameter(name, kind, annotation=typ, **kw)]
     f.__signature__ = sig.replace(parameters=new_params)
     f.__annotations__[name] = typ
     return f

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -4534,7 +4534,7 @@
     "    sig = signature(f)\n",
     "    if name in sig.parameters: return f\n",
     "    kw = {} if default is Parameter.empty else {'default': default}\n",
-    "    new_params = list(sig.parameters.values()) + [Parameter(name, kind, **kw)]\n",
+    "    new_params = list(sig.parameters.values()) + [Parameter(name, kind, annotation=typ, **kw)]\n",
     "    f.__signature__ = sig.replace(parameters=new_params)\n",
     "    f.__annotations__[name] = typ\n",
     "    return f"


### PR DESCRIPTION
`add_sig_param` builds the injected `Parameter` without `annotation=`, storing the type only in `f.__annotations__`. This used to work because fastcore's old `signature_ex` merged `__annotations__` back over an explicit `__signature__`, an undocumented side effect of its pre-3.10 backport. 

The `signature_ex` rewrite in fastcore delegates to stock `inspect.signature`, which returns `__signature__` verbatim. Injected params therefore arrive with no annotation and are ignored by the request machinery. Which explains the failing test in #916 

Fix: pass `annotation=typ` when constructing the Parameter, putting the type in the signature itself.