### PR TITLE
Update CLI flags for fastcore.script hyphenation

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -1,7 +1,7 @@
 project:
   type: website
   pre-render: 
-    - pysym2md --output_file apilist.txt fasthtml
+    - pysym2md --output-file apilist.txt fasthtml
   resources: 
     - "*.txt"
   preview:

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -2,5 +2,4 @@
 python tools/mk_pyi.py
 llms_txt2ctx nbs/llms.txt --optional true > nbs/llms-ctx-full.txt
 llms_txt2ctx nbs/llms.txt > nbs/llms-ctx.txt
-pysym2md --output_file nbs/apilist.txt fasthtml --include_no_docstring
-
+pysym2md --output-file nbs/apilist.txt fasthtml --include-no-docstring


### PR DESCRIPTION
Update affected documentation, automation, tests, and saved notebook output to use the hyphenated CLI flags now generated from underscored `fastcore.script` parameters.

This keeps examples and build/test commands compatible with current fastcore.