### PR TITLE
Update htmx 4 URLs to stable 4.0.0

### DIFF
--- a/fasthtml/core.py
+++ b/fasthtml/core.py
@@ -555,16 +555,16 @@ htmx_exts = {
     "remove-me": "https://cdn.jsdelivr.net/npm/htmx-ext-remove-me@2.0.0/remove-me.js",
     "debug": "https://unpkg.com/htmx.org@1.9.12/dist/ext/debug.js",
     "ws": "https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.3/ws.js",
-    "ws4": "https://unpkg.com/htmx.org@4.0.0-beta6/dist/ext/hx-ws.js",
+    "ws4": "https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/ext/hx-ws.min.js",
     "chunked-transfer": "https://cdn.jsdelivr.net/npm/htmx-ext-transfer-encoding-chunked@0.4.0/transfer-encoding-chunked.js",
-    "sse4": "https://unpkg.com/htmx.org@4.0.0-beta6/dist/ext/hx-sse.js",
-    "live": "https://unpkg.com/htmx.org@4.0.0-beta6/dist/ext/hx-live.js",
-    "multipart": "https://cdn.jsdelivr.net/gh/bigskysoftware/htmx@four/src/ext/hx-multipart.min.js"
+    "sse4": "https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/ext/hx-sse.min.js",
+    "live": "https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/ext/hx-live.min.js",
+    "multipart": "https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/ext/hx-multipart.min.js"
 }
 
 # %% ../nbs/api/00_core.ipynb #60cb52ea
 htmxsrc   = Script(src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.js")
-htmx4src  = Script(src="https://unpkg.com/htmx.org@4.0.0-beta6/dist/htmx.js")
+htmx4src  = Script(src="https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/htmx.min.js")
 fhjsscr   = Script(src="https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js")
 surrsrc   = Script(src="https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js")
 scopesrc  = Script(src="https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js")

--- a/nbs/api/00_core.ipynb
+++ b/nbs/api/00_core.ipynb
@@ -1661,11 +1661,11 @@
     "    \"remove-me\": \"https://cdn.jsdelivr.net/npm/htmx-ext-remove-me@2.0.0/remove-me.js\",\n",
     "    \"debug\": \"https://unpkg.com/htmx.org@1.9.12/dist/ext/debug.js\",\n",
     "    \"ws\": \"https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.3/ws.js\",\n",
-    "    \"ws4\": \"https://unpkg.com/htmx.org@4.0.0-beta6/dist/ext/hx-ws.js\",\n",
+    "    \"ws4\": \"https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/ext/hx-ws.min.js\",\n",
     "    \"chunked-transfer\": \"https://cdn.jsdelivr.net/npm/htmx-ext-transfer-encoding-chunked@0.4.0/transfer-encoding-chunked.js\",\n",
-    "    \"sse4\": \"https://unpkg.com/htmx.org@4.0.0-beta6/dist/ext/hx-sse.js\",\n",
-    "    \"live\": \"https://unpkg.com/htmx.org@4.0.0-beta6/dist/ext/hx-live.js\",\n",
-    "    \"multipart\": \"https://cdn.jsdelivr.net/gh/bigskysoftware/htmx@four/src/ext/hx-multipart.min.js\"\n",
+    "    \"sse4\": \"https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/ext/hx-sse.min.js\",\n",
+    "    \"live\": \"https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/ext/hx-live.min.js\",\n",
+    "    \"multipart\": \"https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/ext/hx-multipart.min.js\"\n",
     "}"
    ]
   },
@@ -1704,7 +1704,7 @@
    "source": [
     "#| export\n",
     "htmxsrc   = Script(src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.js\")\n",
-    "htmx4src  = Script(src=\"https://unpkg.com/htmx.org@4.0.0-beta6/dist/htmx.js\")\n",
+    "htmx4src  = Script(src=\"https://cdn.jsdelivr.net/npm/htmx.org@4.0.0/dist/htmx.min.js\")\n",
     "fhjsscr   = Script(src=\"https://cdn.jsdelivr.net/gh/answerdotai/fasthtml-js@1.0.12/fasthtml.js\")\n",
     "surrsrc   = Script(src=\"https://cdn.jsdelivr.net/gh/answerdotai/surreal@main/surreal.js\")\n",
     "scopesrc  = Script(src=\"https://cdn.jsdelivr.net/gh/gnat/css-scope-inline@main/script.js\")\n",


### PR DESCRIPTION
Updates htmx 4 and its extension from the beta release to stable v4.0.0.
